### PR TITLE
Fix/create dir warning

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -100,7 +100,8 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           Changes in this Release
-          - Fix: Assert/hang on returning error from BlockStoreAPI::GetStoredBlock()
+          - Fix: Removed spam warning when trying to create a directory that already exists
+          - Fix: Content indexes now have correct max-block-size when using Longtail_AddContentIndex()
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -101,7 +101,7 @@ jobs:
         body: |
           Changes in this Release
           - Fix: Removed spam warning when trying to create a directory that already exists
-          - Fix: Content indexes now have correct max-block-size when using Longtail_AddContentIndex()
+          - Fix: Content indexes now have correct max-block-size when using `Longtail_AddContentIndex()`
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/lib/filestorage/longtail_filestorage.c
+++ b/lib/filestorage/longtail_filestorage.c
@@ -188,7 +188,7 @@ static int FSStorageAPI_CreateDir(struct Longtail_StorageAPI* storage_api, const
     int err = Longtail_CreateDirectory(tmp_path);
     if (err)
     {
-        LONGTAIL_LOG(err == EEXIST ? LONGTAIL_LOG_LEVEL_WARNING : LONGTAIL_LOG_LEVEL_ERROR, "FSStorageAPI_CreateDir(%p, %s) failed with %d",
+        LONGTAIL_LOG(err == EEXIST ? LONGTAIL_LOG_LEVEL_INFO : LONGTAIL_LOG_LEVEL_ERROR, "FSStorageAPI_CreateDir(%p, %s) failed with %d",
             storage_api, path,
             err)
         return err;

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -540,16 +540,16 @@ static int SafeCreateDir(struct Longtail_StorageAPI* storage_api, const char* pa
     LONGTAIL_FATAL_ASSERT(storage_api != 0, return EINVAL)
     LONGTAIL_FATAL_ASSERT(path != 0, return EINVAL)
     int err = storage_api->CreateDir(storage_api, path);
-    if ((!err) || (err == EEXIST))
+    if (err)
     {
-        return 0;
+        if ((err == EEXIST) || storage_api->IsDir(storage_api, path))
+        {
+            return 0;
+        }
+        LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_ERROR, "SafeCreateDir(%p, %s) failed with %d", (void*)storage_api, path, err)
+        return err;
     }
-    if (storage_api->IsDir(storage_api, path))
-    {
-        return 0;
-    }
-    LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_ERROR, "SafeCreateDir(%p, %s) failed with %d", (void*)storage_api, path, err)
-    return err;
+    return 0;
 }
 
 int EnsureParentPathExists(struct Longtail_StorageAPI* storage_api, const char* path)
@@ -6169,7 +6169,7 @@ int Longtail_AddContentIndex(
         &content_index[1],
         content_index_size - sizeof(struct Longtail_ContentIndex),
         hash_identifier,
-        *local_content_index->m_MaxChunksPerBlock,
+        *local_content_index->m_MaxBlockSize,
         *local_content_index->m_MaxChunksPerBlock,
         block_count,
         chunk_count);


### PR DESCRIPTION
- Fix: Removed spam warning when trying to create a directory that already exists
- Fix: Content indexes now have correct max-block-size when using Longtail_AddContentIndex()
