### PR TITLE
New: Longtail_BlockStoreAPI::RetargetContent and Longtail_GetMissingContent

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -104,9 +104,13 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           Changes in this Release
-          - Fix: Removed spam warning when scanning empty directories
-          - New: Includes .so for debug and release version on Linux and MacOS
-          - New: dist archives now includes all header files that contains exports
+          - *API CHANGED*: `Longtail_BlockStoreAPI` now expects a `RetargetContent` function
+          - *API ADDED*: `Longtail_GetMissingContent`
+          - Now possible to write/change version without downloading full index from BlockStore
+          - `Longtail_CacheBlockStore` now returns merged content index from local and remote index
+          - Cleaned up blockstore constructors
+          - longtail cmd tool now does downsync without fetching full index from blockstore
+          - `LongtailBlockStore::PreflightGet`: Cache block store filters out blocks it knows before passing to remote store
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/lib/cacheblockstore/longtail_cacheblockstore.c
+++ b/lib/cacheblockstore/longtail_cacheblockstore.c
@@ -592,7 +592,7 @@ struct RetargetContext
 
 static void RetargetContent_GetIndexesCompleteAPI_OnComplete(void* context)
 {
-    struct RetargetContext* retarget_context = context;
+    struct RetargetContext* retarget_context = (struct RetargetContext*)context;
     int err = retarget_context->m_LocalErr ? retarget_context->m_LocalErr : retarget_context->m_RemoteErr;
     if (err)
     {

--- a/lib/cacheblockstore/longtail_cacheblockstore.c
+++ b/lib/cacheblockstore/longtail_cacheblockstore.c
@@ -463,7 +463,7 @@ struct GetIndexContext
 
 static void GetIndex_GetIndexesCompleteAPI_OnComplete(void* context)
 {
-    struct GetIndexContext* retarget_context = (struct GetIndexContext* retarget_context)context;
+    struct GetIndexContext* retarget_context = (struct GetIndexContext*)context;
     int err = retarget_context->m_LocalErr ? retarget_context->m_LocalErr : retarget_context->m_RemoteErr;
     if (err)
     {

--- a/lib/cacheblockstore/longtail_cacheblockstore.c
+++ b/lib/cacheblockstore/longtail_cacheblockstore.c
@@ -15,6 +15,7 @@ struct CacheBlockStoreAPI
     TLongtail_Atomic32 m_PendingRequestCount;
 
     TLongtail_Atomic64 m_IndexGetCount;
+    TLongtail_Atomic64 m_RetargetIndexCount;
     TLongtail_Atomic64 m_BlocksGetCount;
     TLongtail_Atomic64 m_BlocksPutCount;
     TLongtail_Atomic64 m_ChunksGetCount;
@@ -425,6 +426,70 @@ static int CacheBlockStore_GetStoredBlock(
     return 0;
 }
 
+typedef void (*Gather_GetIndexPartialComplete)(void* context);
+
+struct Gather_GetIndexCompleteAPI
+{
+    struct Longtail_AsyncGetIndexAPI m_API;
+    void* m_Context;
+    Gather_GetIndexPartialComplete m_CompleteCallback;
+    struct Longtail_ContentIndex** m_ContentIndex;
+    TLongtail_Atomic32* m_PendingCount;
+    int* m_Err;
+};
+
+static void Gather_GetIndexCompleteAPI_OnComplete(struct Longtail_AsyncGetIndexAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err)
+{
+    struct Gather_GetIndexCompleteAPI* api = (struct Gather_GetIndexCompleteAPI*)async_complete_api;
+    *api->m_Err = err;
+    *api->m_ContentIndex = content_index;
+    if (0 == Longtail_AtomicAdd32(api->m_PendingCount, -1))
+    {
+        api->m_CompleteCallback(api->m_Context);
+    }
+    Longtail_Free(api);
+}
+
+
+struct GetIndexContext
+{
+    struct Longtail_AsyncGetIndexAPI* m_AsyncCompleteAPI;
+    struct Longtail_ContentIndex* m_LocalIndex;
+    struct Longtail_ContentIndex* m_RemoteIndex;
+    TLongtail_Atomic32 m_PendingCount;
+    int m_LocalErr;
+    int m_RemoteErr;
+};
+
+static void GetIndex_GetIndexesCompleteAPI_OnComplete(void* context)
+{
+    struct GetIndexContext* retarget_context = context;
+    int err = retarget_context->m_LocalErr ? retarget_context->m_LocalErr : retarget_context->m_RemoteErr;
+    if (err)
+    {
+        Longtail_Free(retarget_context->m_LocalIndex);
+        Longtail_Free(retarget_context->m_RemoteIndex);
+        retarget_context->m_AsyncCompleteAPI->OnComplete(retarget_context->m_AsyncCompleteAPI, 0, err);
+        Longtail_Free(retarget_context);
+        return;
+    }
+    struct Longtail_ContentIndex* full_content_index = 0;
+    err = Longtail_MergeContentIndex(retarget_context->m_RemoteIndex, retarget_context->m_LocalIndex, &full_content_index);
+    Longtail_Free(retarget_context->m_LocalIndex);
+    Longtail_Free(retarget_context->m_RemoteIndex);
+    if (err)
+    {
+        LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_ERROR, "GetIndex_GetIndexesCompleteAPI_OnComplete(%p) failed with %d",
+            context,
+            err)
+        retarget_context->m_AsyncCompleteAPI->OnComplete(retarget_context->m_AsyncCompleteAPI, 0, err);
+        Longtail_Free(retarget_context);
+        return;
+    }
+    retarget_context->m_AsyncCompleteAPI->OnComplete(retarget_context->m_AsyncCompleteAPI, full_content_index, 0);
+    Longtail_Free(retarget_context);
+}
+
 static int CacheBlockStore_GetIndex(
     struct Longtail_BlockStoreAPI* block_store_api,
     struct Longtail_AsyncGetIndexAPI* async_complete_api)
@@ -435,17 +500,246 @@ static int CacheBlockStore_GetIndex(
 
     struct CacheBlockStoreAPI* cacheblockstore_api = (struct CacheBlockStoreAPI*)block_store_api;
     Longtail_AtomicAdd64(&cacheblockstore_api->m_IndexGetCount, 1);
-    return cacheblockstore_api->m_RemoteBlockStoreAPI->GetIndex(cacheblockstore_api->m_RemoteBlockStoreAPI, async_complete_api);
+
+    size_t getindex_context_size = sizeof(struct GetIndexContext);
+    struct GetIndexContext* getindex_context = (struct GetIndexContext*)Longtail_Alloc(getindex_context_size);
+    if (!getindex_context)
+    {
+        LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_ERROR, "CacheBlockStore_GetIndex(%p, %u, %p) failed with %d",
+            block_store_api, async_complete_api,
+            ENOMEM)
+        return ENOMEM;
+    }
+
+    size_t get_local_index_size = sizeof(struct Gather_GetIndexCompleteAPI);
+    struct Gather_GetIndexCompleteAPI* get_local_index = (struct Gather_GetIndexCompleteAPI*)Longtail_Alloc(get_local_index_size);
+    if (!get_local_index)
+    {
+        LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_ERROR, "CacheBlockStore_GetIndex(%p, %u, %p) failed with %d",
+            block_store_api, async_complete_api,
+            ENOMEM)
+        Longtail_Free(getindex_context);
+        return ENOMEM;
+    }
+
+    size_t get_remote_index_size = sizeof(struct Gather_GetIndexCompleteAPI);
+    struct Gather_GetIndexCompleteAPI* get_remote_index = (struct Gather_GetIndexCompleteAPI*)Longtail_Alloc(get_remote_index_size);
+    if (!get_remote_index)
+    {
+        LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_ERROR, "CacheBlockStore_GetIndex(%p, %u, %p) failed with %d",
+            block_store_api, async_complete_api,
+            ENOMEM)
+        Longtail_Free(get_local_index);
+        Longtail_Free(getindex_context);
+        return ENOMEM;
+    }
+
+    getindex_context->m_AsyncCompleteAPI = async_complete_api;
+    getindex_context->m_LocalIndex = 0;
+    getindex_context->m_RemoteIndex = 0;
+    getindex_context->m_PendingCount = 2;
+    getindex_context->m_LocalErr = EINVAL;
+    getindex_context->m_RemoteErr = EINVAL;
+
+    get_local_index->m_Context = getindex_context;
+    get_local_index->m_CompleteCallback = GetIndex_GetIndexesCompleteAPI_OnComplete;
+    get_local_index->m_ContentIndex = &getindex_context->m_LocalIndex;
+    get_local_index->m_Err = &getindex_context->m_LocalErr;
+    get_local_index->m_PendingCount = &getindex_context->m_PendingCount;
+
+    get_remote_index->m_Context = getindex_context;
+    get_remote_index->m_CompleteCallback = GetIndex_GetIndexesCompleteAPI_OnComplete;
+    get_remote_index->m_ContentIndex = &getindex_context->m_RemoteIndex;
+    get_remote_index->m_Err = &getindex_context->m_RemoteErr;
+    get_remote_index->m_PendingCount = &getindex_context->m_PendingCount;
+
+    struct Longtail_AsyncGetIndexAPI* get_local_async_api = Longtail_MakeAsyncGetIndexAPI(
+        get_local_index,
+        0,
+        Gather_GetIndexCompleteAPI_OnComplete);
+    LONGTAIL_FATAL_ASSERT(get_local_async_api != 0, return EINVAL)
+
+    struct Longtail_AsyncGetIndexAPI* get_remote_async_api = Longtail_MakeAsyncGetIndexAPI(
+        get_remote_index,
+        0,
+        Gather_GetIndexCompleteAPI_OnComplete);
+    LONGTAIL_FATAL_ASSERT(get_remote_async_api != 0, return EINVAL)
+
+    int err = Longtail_BlockStore_GetIndex(cacheblockstore_api->m_LocalBlockStoreAPI, get_local_async_api);
+    if (err)
+    {
+        Gather_GetIndexCompleteAPI_OnComplete(get_local_async_api, 0, err);
+    }
+
+    err = Longtail_BlockStore_GetIndex(cacheblockstore_api->m_RemoteBlockStoreAPI, get_remote_async_api);
+    if (err)
+    {
+        Gather_GetIndexCompleteAPI_OnComplete(get_remote_async_api, 0, err);
+    }
+    return 0;
+}
+
+struct RetargetContext
+{
+    struct Longtail_ContentIndex* m_ContentIndex;
+    struct Longtail_AsyncRetargetContentAPI* m_AsyncCompleteAPI;
+    struct Longtail_ContentIndex* m_LocalIndex;
+    struct Longtail_ContentIndex* m_RemoteIndex;
+    TLongtail_Atomic32 m_PendingCount;
+    int m_LocalErr;
+    int m_RemoteErr;
+};
+
+static void RetargetContent_GetIndexesCompleteAPI_OnComplete(void* context)
+{
+    struct RetargetContext* retarget_context = context;
+    int err = retarget_context->m_LocalErr ? retarget_context->m_LocalErr : retarget_context->m_RemoteErr;
+    if (err)
+    {
+        Longtail_Free(retarget_context->m_LocalIndex);
+        Longtail_Free(retarget_context->m_RemoteIndex);
+        Longtail_Free(retarget_context->m_ContentIndex);
+        retarget_context->m_AsyncCompleteAPI->OnComplete(retarget_context->m_AsyncCompleteAPI, 0, err);
+        Longtail_Free(retarget_context);
+        return;
+    }
+    struct Longtail_ContentIndex* full_content_index = 0;
+    err = Longtail_MergeContentIndex(retarget_context->m_RemoteIndex, retarget_context->m_LocalIndex, &full_content_index);
+    Longtail_Free(retarget_context->m_LocalIndex);
+    Longtail_Free(retarget_context->m_RemoteIndex);
+    if (err)
+    {
+        retarget_context->m_AsyncCompleteAPI->OnComplete(retarget_context->m_AsyncCompleteAPI, 0, err);
+        Longtail_Free(retarget_context->m_ContentIndex);
+        Longtail_Free(retarget_context);
+        return;
+    }
+    struct Longtail_ContentIndex* retargeted_content_index = 0;
+    err = Longtail_RetargetContent(full_content_index, retarget_context->m_ContentIndex, &retargeted_content_index);
+    Longtail_Free(full_content_index);
+    Longtail_Free(retarget_context->m_ContentIndex);
+    if (err)
+    {
+        retarget_context->m_AsyncCompleteAPI->OnComplete(retarget_context->m_AsyncCompleteAPI, 0, err);
+        Longtail_Free(retarget_context);
+        return;
+    }
+    retarget_context->m_AsyncCompleteAPI->OnComplete(retarget_context->m_AsyncCompleteAPI, retargeted_content_index, 0);
+    Longtail_Free(retarget_context);
+}
+
+static int CacheBlockStore_RetargetContent(
+    struct Longtail_BlockStoreAPI* block_store_api,
+    struct Longtail_ContentIndex* content_index,
+    struct Longtail_AsyncRetargetContentAPI* async_complete_api)
+{
+    LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_DEBUG, "CacheBlockStore_RetargetContent(%p, %p, %p)",
+        block_store_api, content_index, async_complete_api)
+    LONGTAIL_VALIDATE_INPUT(block_store_api, return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(content_index, return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(async_complete_api, return EINVAL)
+
+    struct CacheBlockStoreAPI* cacheblockstore_api = (struct CacheBlockStoreAPI*)block_store_api;
+    Longtail_AtomicAdd64(&cacheblockstore_api->m_RetargetIndexCount, 1);
+
+    size_t retarget_context_size = sizeof(struct RetargetContext);
+    struct RetargetContext* retarget_context = (struct RetargetContext*)Longtail_Alloc(retarget_context_size);
+    if (!retarget_context_size)
+    {
+        return ENOMEM;
+    }
+
+    size_t get_local_index_size = sizeof(struct Gather_GetIndexCompleteAPI);
+    struct Gather_GetIndexCompleteAPI* get_local_index = (struct Gather_GetIndexCompleteAPI*)Longtail_Alloc(get_local_index_size);
+    if (!get_local_index)
+    {
+        Longtail_Free(retarget_context);
+        return ENOMEM;
+    }
+
+    size_t get_remote_index_size = sizeof(struct Gather_GetIndexCompleteAPI);
+    struct Gather_GetIndexCompleteAPI* get_remote_index = (struct Gather_GetIndexCompleteAPI*)Longtail_Alloc(get_remote_index_size);
+    if (!get_remote_index)
+    {
+        Longtail_Free(get_local_index);
+        Longtail_Free(retarget_context);
+        return ENOMEM;
+    }
+    void* tmp_buffer;
+    size_t tmp_size;
+    int err = Longtail_WriteContentIndexToBuffer(content_index, &tmp_buffer, &tmp_size);
+    if (err)
+    {
+        Longtail_Free(get_remote_index);
+        Longtail_Free(get_local_index);
+        Longtail_Free(retarget_context);
+        return err;
+    }
+    struct Longtail_ContentIndex* content_index_copy = 0;
+    err = Longtail_ReadContentIndexFromBuffer(tmp_buffer, tmp_size, &content_index_copy);
+    Longtail_Free(tmp_buffer);
+    if (err)
+    {
+        Longtail_Free(get_remote_index);
+        Longtail_Free(get_local_index);
+        Longtail_Free(retarget_context);
+        return err;
+    }
+
+    retarget_context->m_ContentIndex = content_index_copy;
+    retarget_context->m_AsyncCompleteAPI = async_complete_api;
+    retarget_context->m_LocalIndex = 0;
+    retarget_context->m_RemoteIndex = 0;
+    retarget_context->m_PendingCount = 2;
+    retarget_context->m_LocalErr = EINVAL;
+    retarget_context->m_RemoteErr = EINVAL;
+
+    get_local_index->m_Context = retarget_context;
+    get_local_index->m_CompleteCallback = RetargetContent_GetIndexesCompleteAPI_OnComplete;
+    get_local_index->m_ContentIndex = &retarget_context->m_LocalIndex;
+    get_local_index->m_Err = &retarget_context->m_LocalErr;
+    get_local_index->m_PendingCount = &retarget_context->m_PendingCount;
+
+    get_remote_index->m_Context = retarget_context;
+    get_remote_index->m_CompleteCallback = RetargetContent_GetIndexesCompleteAPI_OnComplete;
+    get_remote_index->m_ContentIndex = &retarget_context->m_RemoteIndex;
+    get_remote_index->m_Err = &retarget_context->m_RemoteErr;
+    get_remote_index->m_PendingCount = &retarget_context->m_PendingCount;
+
+    struct Longtail_AsyncGetIndexAPI* get_local_async_api = Longtail_MakeAsyncGetIndexAPI(
+        get_local_index,
+        0,
+        Gather_GetIndexCompleteAPI_OnComplete);
+    LONGTAIL_FATAL_ASSERT(get_local_async_api != 0, return EINVAL)
+
+    struct Longtail_AsyncGetIndexAPI* get_remote_async_api = Longtail_MakeAsyncGetIndexAPI(
+        get_remote_index,
+        0,
+        Gather_GetIndexCompleteAPI_OnComplete);
+    LONGTAIL_FATAL_ASSERT(get_remote_async_api != 0, return EINVAL)
+
+    err = Longtail_BlockStore_GetIndex(cacheblockstore_api->m_LocalBlockStoreAPI, get_local_async_api);
+    if (err)
+    {
+        Gather_GetIndexCompleteAPI_OnComplete(get_local_async_api, 0, err);
+    }
+
+    err = Longtail_BlockStore_GetIndex(cacheblockstore_api->m_RemoteBlockStoreAPI, get_remote_async_api);
+    if (err)
+    {
+        Gather_GetIndexCompleteAPI_OnComplete(get_remote_async_api, 0, err);
+    }
+    return 0;
 }
 
 static int CacheBlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats)
 {
     LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_DEBUG, "CacheBlockStore_GetStats(%p, %p)", block_store_api, out_stats)
-    LONGTAIL_VALIDATE_INPUT(block_store_api, return EINVAL)
-    LONGTAIL_VALIDATE_INPUT(out_stats, return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(block_store_api, return EINVAL)LONGTAIL_VALIDATE_INPUT(out_stats, return EINVAL)
     struct CacheBlockStoreAPI* cacheblockstore_api = (struct CacheBlockStoreAPI*)block_store_api;
     memset(out_stats, 0, sizeof(struct Longtail_BlockStore_Stats));
     out_stats->m_IndexGetCount = cacheblockstore_api->m_IndexGetCount;
+//    out_stats->m_RetargetIndexCount = cacheblockstore_api->m_RetargetIndexCount;
     out_stats->m_BlocksGetCount = cacheblockstore_api->m_BlocksGetCount;
     out_stats->m_BlocksPutCount = cacheblockstore_api->m_BlocksPutCount;
     out_stats->m_ChunksGetCount = cacheblockstore_api->m_ChunksGetCount;
@@ -481,21 +775,34 @@ static void CacheBlockStore_Dispose(struct Longtail_API* api)
 }
 
 static int CacheBlockStore_Init(
-    struct CacheBlockStoreAPI* api,
+    void* mem,
     struct Longtail_BlockStoreAPI* local_block_store,
-    struct Longtail_BlockStoreAPI* remote_block_store)
+    struct Longtail_BlockStoreAPI* remote_block_store,
+    struct Longtail_BlockStoreAPI** out_block_store_api)
 {
-    LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_DEBUG, "CacheBlockStore_Dispose(%p, %p, %p)", api, local_block_store, remote_block_store)
-    LONGTAIL_FATAL_ASSERT(api, return EINVAL)
+    LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_DEBUG, "CacheBlockStore_Dispose(%p, %p, %p, %p)",
+        mem, local_block_store, remote_block_store, out_block_store_api)
+    LONGTAIL_FATAL_ASSERT(mem, return EINVAL)
     LONGTAIL_FATAL_ASSERT(local_block_store, return EINVAL)
     LONGTAIL_FATAL_ASSERT(remote_block_store, return EINVAL)
+    LONGTAIL_FATAL_ASSERT(out_block_store_api, return EINVAL)
 
-    api->m_BlockStoreAPI.m_API.Dispose = CacheBlockStore_Dispose;
-    api->m_BlockStoreAPI.PutStoredBlock = CacheBlockStore_PutStoredBlock;
-    api->m_BlockStoreAPI.PreflightGet = CacheBlockStore_PreflightGet;
-    api->m_BlockStoreAPI.GetStoredBlock = CacheBlockStore_GetStoredBlock;
-    api->m_BlockStoreAPI.GetIndex = CacheBlockStore_GetIndex;
-    api->m_BlockStoreAPI.GetStats = CacheBlockStore_GetStats;
+    struct Longtail_BlockStoreAPI* block_store_api = Longtail_MakeBlockStoreAPI(
+        mem,
+        CacheBlockStore_Dispose,
+        CacheBlockStore_PutStoredBlock,
+        CacheBlockStore_PreflightGet,
+        CacheBlockStore_GetStoredBlock,
+        CacheBlockStore_GetIndex,
+        CacheBlockStore_RetargetContent,
+        CacheBlockStore_GetStats);
+    if (!block_store_api)
+    {
+        return EINVAL;
+    }
+
+    struct CacheBlockStoreAPI* api = (struct CacheBlockStoreAPI*)block_store_api;
+
     api->m_LocalBlockStoreAPI = local_block_store;
     api->m_RemoteBlockStoreAPI = remote_block_store;
     api->m_PendingRequestCount = 0;
@@ -514,6 +821,7 @@ static int CacheBlockStore_Init(
     api->m_BlockGetFailCount = 0;
     api->m_BlockPutFailCount = 0;
 
+    *out_block_store_api = block_store_api;
     return 0;
 }
 
@@ -526,22 +834,24 @@ struct Longtail_BlockStoreAPI* Longtail_CreateCacheBlockStoreAPI(
     LONGTAIL_VALIDATE_INPUT(remote_block_store, return 0)
 
     size_t api_size = sizeof(struct CacheBlockStoreAPI);
-    struct CacheBlockStoreAPI* api = (struct CacheBlockStoreAPI*)Longtail_Alloc(api_size);
-    if (!api)
+    void* mem = Longtail_Alloc(api_size);
+    if (!mem)
     {
         LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_ERROR, "CacheBlockStore_PutStoredBlock(%p, %p) failed with %d",
             local_block_store, remote_block_store,
             ENOMEM)
         return 0;
     }
+    struct Longtail_BlockStoreAPI* block_store_api;
     int err = CacheBlockStore_Init(
-        api,
+        mem,
         local_block_store,
-        remote_block_store);
+        remote_block_store,
+        &block_store_api);
     if (err)
     {
-        Longtail_Free(api);
+        Longtail_Free(mem);
         return 0;
     }
-    return &api->m_BlockStoreAPI;
+    return block_store_api;
 }

--- a/lib/cacheblockstore/longtail_cacheblockstore.c
+++ b/lib/cacheblockstore/longtail_cacheblockstore.c
@@ -463,7 +463,7 @@ struct GetIndexContext
 
 static void GetIndex_GetIndexesCompleteAPI_OnComplete(void* context)
 {
-    struct GetIndexContext* retarget_context = context;
+    struct GetIndexContext* retarget_context = (struct GetIndexContext* retarget_context)context;
     int err = retarget_context->m_LocalErr ? retarget_context->m_LocalErr : retarget_context->m_RemoteErr;
     if (err)
     {

--- a/lib/cacheblockstore/longtail_cacheblockstore.c
+++ b/lib/cacheblockstore/longtail_cacheblockstore.c
@@ -222,6 +222,7 @@ void PreflightGetLocalStoreIndexOnComplete(struct Longtail_AsyncGetIndexAPI* asy
 
     Longtail_Free(api->m_PreflightBlockRefCounts);
     Longtail_Free(api->m_PreflightBlockHashes);
+    Longtail_Free(content_index);
     Longtail_Free(api);
     if (err)
     {

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -464,6 +464,27 @@ LONGTAIL_EXPORT struct Longtail_AsyncGetIndexAPI* Longtail_MakeAsyncGetIndexAPI(
 
 LONGTAIL_EXPORT void Longtail_AsyncGetIndex_OnComplete(struct Longtail_AsyncGetIndexAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err);
 
+////////////// Longtail_AsyncRetargetContentAPI
+
+struct Longtail_AsyncRetargetContentAPI;
+
+typedef void (*Longtail_AsyncRetargetContent_OnCompleteFunc)(struct Longtail_AsyncRetargetContentAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err);
+
+struct Longtail_AsyncRetargetContentAPI
+{
+    struct Longtail_API m_API;
+    Longtail_AsyncRetargetContent_OnCompleteFunc OnComplete;
+};
+
+LONGTAIL_EXPORT uint64_t Longtail_GetAsyncRetargetContentAPISize();
+
+LONGTAIL_EXPORT struct Longtail_AsyncRetargetContentAPI* Longtail_MakeAsyncRetargetContentAPI(
+    void* mem,
+    Longtail_DisposeFunc dispose_func,
+    Longtail_AsyncRetargetContent_OnCompleteFunc on_complete_func);
+
+LONGTAIL_EXPORT void Longtail_AsyncRetargetContent_OnComplete(struct Longtail_AsyncRetargetContentAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err);
+
 ////////////// Longtail_BlockStoreAPI
 
 struct Longtail_BlockStoreAPI;
@@ -489,6 +510,7 @@ typedef int (*Longtail_BlockStore_PutStoredBlockFunc)(struct Longtail_BlockStore
 typedef int (*Longtail_BlockStore_PreflightGetFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_count, const TLongtail_Hash* block_hashes, const uint32_t* block_ref_counts);
 typedef int (*Longtail_BlockStore_GetStoredBlockFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_hash, struct Longtail_AsyncGetStoredBlockAPI* async_complete_api);
 typedef int (*Longtail_BlockStore_GetIndexFunc)(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_AsyncGetIndexAPI* async_complete_api);
+typedef int (*Longtail_BlockStore_RetargetContentFunc)(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_ContentIndex* content_index, struct Longtail_AsyncRetargetContentAPI* async_complete_api);
 typedef int (*Longtail_BlockStore_GetStatsFunc)(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats);
 
 struct Longtail_BlockStoreAPI
@@ -498,6 +520,7 @@ struct Longtail_BlockStoreAPI
     Longtail_BlockStore_PreflightGetFunc PreflightGet;
     Longtail_BlockStore_GetStoredBlockFunc GetStoredBlock;
     Longtail_BlockStore_GetIndexFunc GetIndex;
+    Longtail_BlockStore_RetargetContentFunc RetargetContent;
     Longtail_BlockStore_GetStatsFunc GetStats;
 };
 
@@ -511,12 +534,14 @@ LONGTAIL_EXPORT struct Longtail_BlockStoreAPI* Longtail_MakeBlockStoreAPI(
     Longtail_BlockStore_PreflightGetFunc preflight_get_func,
     Longtail_BlockStore_GetStoredBlockFunc get_stored_block_func,
     Longtail_BlockStore_GetIndexFunc get_index_func,
+    Longtail_BlockStore_RetargetContentFunc retarget_content_func,
     Longtail_BlockStore_GetStatsFunc get_stats_func);
 
 LONGTAIL_EXPORT int Longtail_BlockStore_PutStoredBlock(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_StoredBlock* stored_block, struct Longtail_AsyncPutStoredBlockAPI* async_complete_api);
 LONGTAIL_EXPORT int Longtail_BlockStore_PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_count, const TLongtail_Hash* block_hashes, const uint32_t* block_ref_counts);
 LONGTAIL_EXPORT int Longtail_BlockStore_GetStoredBlock(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_hash, struct Longtail_AsyncGetStoredBlockAPI* async_complete_api);
 LONGTAIL_EXPORT int Longtail_BlockStore_GetIndex(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_AsyncGetIndexAPI* async_complete_api);
+LONGTAIL_EXPORT int Longtail_BlockStore_RetargetContent(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_ContentIndex* content_index, struct Longtail_AsyncRetargetContentAPI* async_complete_api);
 LONGTAIL_EXPORT int Longtail_BlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats);
 
 typedef void (*Longtail_Assert)(const char* expression, const char* file, int line);
@@ -708,6 +733,12 @@ LONGTAIL_EXPORT int Longtail_CreateMissingContent(
     uint32_t max_chunks_per_block,
     struct Longtail_ContentIndex** out_content_index);
 
+LONGTAIL_EXPORT int Longtail_GetMissingContent(
+    struct Longtail_HashAPI* hash_api,
+    const struct Longtail_ContentIndex* reference_content_index,
+    const struct Longtail_ContentIndex* content_index,
+    struct Longtail_ContentIndex** out_content_index);
+
 LONGTAIL_EXPORT int Longtail_RetargetContent(
     const struct Longtail_ContentIndex* reference_content_index,
     const struct Longtail_ContentIndex* content_index,
@@ -715,12 +746,12 @@ LONGTAIL_EXPORT int Longtail_RetargetContent(
 
 LONGTAIL_EXPORT int Longtail_MergeContentIndex(
     struct Longtail_ContentIndex* local_content_index,
-    struct Longtail_ContentIndex* remote_content_index,
+    struct Longtail_ContentIndex* new_content_index,
     struct Longtail_ContentIndex** out_content_index);
 
 LONGTAIL_EXPORT int Longtail_AddContentIndex(
     struct Longtail_ContentIndex* local_content_index,
-    struct Longtail_ContentIndex* remote_content_index,
+    struct Longtail_ContentIndex* new_content_index,
     struct Longtail_ContentIndex** out_content_index);
 
 LONGTAIL_EXPORT int Longtail_WriteVersion(

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -5051,7 +5051,7 @@ static struct Longtail_ContentIndex* SyncRetargetContent(Longtail_BlockStoreAPI*
 static struct Longtail_ContentIndex* SyncGetContentIndex(Longtail_BlockStoreAPI* block_store)
 {
     TestAsyncGetIndexComplete get_local_index_complete;
-    if (0, block_store->GetIndex(block_store, &get_local_index_complete.m_API))
+    if (block_store->GetIndex(block_store, &get_local_index_complete.m_API))
     {
         return 0;
     }
@@ -5230,6 +5230,7 @@ TEST(Longtail, BlockStoreRetargetContent)
         version_index_1,
         root_path_1));
 
+    Longtail_Free(retarget_cache_content_index);
     retarget_cache_content_index = SyncRetargetContent(cached_block_store_api, version_1_content_index);
     ASSERT_EQ(*version_1_content_index->m_BlockCount, *retarget_cache_content_index->m_BlockCount);
     ASSERT_EQ(*version_1_content_index->m_ChunkCount, *retarget_cache_content_index->m_ChunkCount);
@@ -5394,6 +5395,7 @@ TEST(Longtail, BlockStoreRetargetContent)
     Longtail_Free(version_index_3);
     Longtail_Free(update_content_index_3);
 
+    Longtail_Free(version_2_update_content_index);
     Longtail_Free(version_1_update_content_index);
     Longtail_Free(version_diff);
     Longtail_Free(version_index_2);


### PR DESCRIPTION
Added `Longtail_BlockStoreAPI::RetargetContent` and `Longtail_GetMissingContent`

Now possible to write/change version without downloading full index from BlockStore
cacheblockstore now returns merged content index from local and remote index
Cleaned up blockstore constructors
longtail cmd tool now does downsync without fetching full index from blockstore