### PR TITLE
Add StoreIndex including init, create, load and save functions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -121,9 +121,20 @@ jobs:
         tag_name: ${{ github.ref }}
         release_name: Release ${{ github.ref }}
         body: |
-          Changes in this Release
-          - *FIXED* FSBlockStore sometimes lost blocks in store.lci when flushing
-          - *FIXED* Removing read-only file on Win32 now works
+          # Changes in this Release
+          - **API CHANGE** `Longtail_ContentIndex_BlockHashes` now returns `const TLongtail_Hash*`
+          - **ADDED** `struct Longtail_StoreIndex` contaning all info in a set of block indexes - chunk duplicates allowed. Accessor functions
+          - **ADDED** Functions for `struct Longtail_StoreIndex`
+            - `Longtail_GetStoreIndexSize`
+            - `Longtail_CreateStoreIndexFromBlocks`
+            - `Longtail_MergeStoreIndex`
+            - `Longtail_MakeBlockIndex`
+            - `Longtail_GetExistingContentIndex`
+            - `Longtail_WriteStoreIndexToBuffer`
+            - `Longtail_ReadStoreIndexFromBuffer`
+            - `Longtail_WriteStoreIndex`
+            - `Longtail_ReadStoreIndex`
+          - **CHANGED** FSBlockStore now uses `struct Longtail_StoreIndex` instead of `struct Longtail_ContentIndex`
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/lib/fsblockstore/longtail_fsblockstore.c
+++ b/lib/fsblockstore/longtail_fsblockstore.c
@@ -951,6 +951,7 @@ static int FSBlockStore_RetargetContent(
         Longtail_Free(store_index);
         return err;
     }
+    Longtail_Free(store_index);
     async_complete_api->OnComplete(async_complete_api, existing_content_index, 0);
     return 0;
 }

--- a/lib/fsblockstore/longtail_fsblockstore.c
+++ b/lib/fsblockstore/longtail_fsblockstore.c
@@ -297,7 +297,7 @@ static int UpdateStoreIndex(
     struct Longtail_StoreIndex* added_store_index;
     int err = Longtail_CreateStoreIndexFromBlocks(
         (uint32_t)(arrlen(added_block_indexes)),
-        added_block_indexes,
+        (const struct Longtail_BlockIndex** )added_block_indexes,
         &added_store_index);
     if (err)
     {
@@ -546,7 +546,7 @@ static int ReadContent(
 
     err = Longtail_CreateStoreIndexFromBlocks(
         block_count,
-        block_indexes,
+        (const struct Longtail_BlockIndex**)block_indexes,
         out_store_index);
 
     for (uint32_t b = 0; b < block_count; ++b)

--- a/lib/fsblockstore/longtail_fsblockstore.c
+++ b/lib/fsblockstore/longtail_fsblockstore.c
@@ -933,9 +933,12 @@ static int FSBlockStore_RetargetContent(
         Longtail_AtomicAdd64(&fsblockstore_api->m_StatU64[Longtail_BlockStoreAPI_StatU64_RetargetContent_FailCount], 1);
         return err;
     }
+
     struct Longtail_ContentIndex* store_content_index;
     err = Longtail_CreateContentIndexFromStoreIndex(
         store_index,
+        fsblockstore_api->m_DefaultMaxBlockSize,
+        fsblockstore_api->m_DefaultMaxChunksPerBlock,
         &store_content_index);
     if (err)
     {

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -46,7 +46,9 @@ void Longtail_NukeFree(void* p);
 #define LONGTAIL_CONTENT_INDEX_VERSION_1_0_0  LONGTAIL_VERSION(1,0,0)
 #define LONGTAIL_STORE_INDEX_VERSION_1_0_0    LONGTAIL_VERSION(1,0,0)
 
-uint32_t Longtail_CurrentContentIndexVersion = LONGTAIL_VERSION_INDEX_VERSION_0_0_2;
+uint32_t Longtail_CurrentContentIndexVersion = LONGTAIL_CONTENT_INDEX_VERSION_1_0_0;
+uint32_t Longtail_CurrentVersionIndexVersion = LONGTAIL_VERSION_INDEX_VERSION_0_0_2;
+uint32_t Longtail_CurrentStoreIndexVersion = LONGTAIL_STORE_INDEX_VERSION_1_0_0;
 
 #if defined(_WIN32)
     #define SORTFUNC(name) int name(void* context, const void* a_ptr, const void* b_ptr)
@@ -1875,7 +1877,7 @@ static int InitVersionIndexFromData(
 
     if ((*version_index->m_Version) != LONGTAIL_VERSION_INDEX_VERSION_0_0_2)
     {
-        LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_WARNING, "Missmatching versions in version index data %" PRIu64 " != %" PRIu64 "", (void*)version_index->m_Version, Longtail_CurrentContentIndexVersion);
+        LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_WARNING, "Missmatching versions in version index data %" PRIu64 " != %" PRIu64 "", (void*)version_index->m_Version, Longtail_CurrentVersionIndexVersion);
         LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_ERROR, "InitVersionIndexFromData(%p, %p, %" PRIu64 ") failed with %d",
             (void*)version_index, data, data_size,
             EBADF)
@@ -1997,7 +1999,7 @@ int Longtail_BuildVersionIndex(
     version_index->m_AssetCount = &p[3];
     version_index->m_ChunkCount = &p[4];
     version_index->m_AssetChunkIndexCount = &p[5];
-    *version_index->m_Version = Longtail_CurrentContentIndexVersion;
+    *version_index->m_Version = Longtail_CurrentVersionIndexVersion;
     *version_index->m_HashIdentifier = hash_api_identifier;
     *version_index->m_TargetChunkSize = target_chunk_size;
     *version_index->m_AssetCount = asset_count;
@@ -3199,7 +3201,7 @@ int Longtail_InitContentIndex(
     content_index->m_ChunkCount = (uint64_t*)(void*)p;
     p += sizeof(uint64_t);
 
-    *content_index->m_Version = LONGTAIL_CONTENT_INDEX_VERSION_1_0_0;
+    *content_index->m_Version = Longtail_CurrentContentIndexVersion;
     *content_index->m_HashIdentifier = hash_api;
     *content_index->m_MaxBlockSize = max_block_size;
     *content_index->m_MaxChunksPerBlock = max_chunks_per_block;
@@ -7587,6 +7589,10 @@ static int InitStoreIndexFromData(
     {
         return EBADF;
     }
+    if (*store_index->m_Version != LONGTAIL_STORE_INDEX_VERSION_1_0_0)
+    {
+        return EBADF;
+    }
 
     store_index->m_BlockHashes = (TLongtail_Hash*)(void*)p;
     p += sizeof(TLongtail_Hash) * block_count;
@@ -7658,7 +7664,7 @@ LONGTAIL_EXPORT int Longtail_CreateStoreIndex(
         return ENOMEM;
     }
 
-    *store_index->m_Version = LONGTAIL_STORE_INDEX_VERSION_1_0_0;
+    *store_index->m_Version = Longtail_CurrentStoreIndexVersion;
     *store_index->m_HashIdentifier = hash_identifier;
     uint32_t c = 0;
 

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -7731,12 +7731,8 @@ LONGTAIL_EXPORT int Longtail_CreateStoreIndexFromBlocks(
         store_index->m_BlockTags[b] = *block_index->m_Tag;
         store_index->m_BlockChunkCounts[b] = block_chunk_count;
         store_index->m_BlockChunksOffsets[b] = c;
-        for (uint32_t block_chunk = 0; block_chunk < block_chunk_count; ++block_chunk)
-        {
-            uint32_t stored_chunk_index = c + b;
-            store_index->m_ChunkHashes[stored_chunk_index] = block_index->m_ChunkHashes[block_chunk];
-            store_index->m_ChunkSizes[stored_chunk_index] = block_index->m_ChunkSizes[block_chunk];
-        }
+        memcpy(&store_index->m_ChunkHashes[c], block_index->m_ChunkHashes, sizeof(TLongtail_Hash) * block_chunk_count);
+        memcpy(&store_index->m_ChunkSizes[c], block_index->m_ChunkSizes, sizeof(uint32_t) * block_chunk_count);
         c += block_chunk_count;
     }
 
@@ -7755,10 +7751,10 @@ int Longtail_MakeBlockIndex(
     LONGTAIL_VALIDATE_INPUT(block_index < (*store_index->m_BlockCount), return EINVAL)
     LONGTAIL_VALIDATE_INPUT(store_index != 0, return EINVAL)
     uint32_t block_chunks_offset = store_index->m_BlockChunksOffsets[block_index];
-    *out_block_index->m_BlockHash = store_index->m_BlockHashes[block_index];
-    *out_block_index->m_HashIdentifier = *store_index->m_HashIdentifier;
-    *out_block_index->m_ChunkCount = store_index->m_BlockChunkCounts[block_chunks_offset];
-    *out_block_index->m_Tag = store_index->m_BlockTags[block_index];
+    out_block_index->m_BlockHash = &store_index->m_BlockHashes[block_index];
+    out_block_index->m_HashIdentifier = store_index->m_HashIdentifier;
+    out_block_index->m_ChunkCount = &store_index->m_BlockChunkCounts[block_index];
+    out_block_index->m_Tag = &store_index->m_BlockTags[block_index];
     out_block_index->m_ChunkHashes = &store_index->m_ChunkHashes[block_chunks_offset];
     out_block_index->m_ChunkSizes = &store_index->m_ChunkSizes[block_chunks_offset];
     return 0;

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -1048,6 +1048,8 @@ LONGTAIL_EXPORT int Longtail_CreateContentIndexRaw(
 
 LONGTAIL_EXPORT int Longtail_CreateContentIndexFromStoreIndex(
     const struct Longtail_StoreIndex* store_index,
+    uint32_t max_block_size,
+    uint32_t max_chunks_per_block,
     struct Longtail_ContentIndex** out_content_index);
 
 /*! @brief Writes a struct Longtail_ContentIndex to a byte buffer.
@@ -1669,6 +1671,11 @@ LONGTAIL_EXPORT int Longtail_MergeStoreIndex(
     const struct Longtail_StoreIndex* local_store_index,
     const struct Longtail_StoreIndex* remote_store_index,
     struct Longtail_StoreIndex** out_store_index);
+
+LONGTAIL_EXPORT int Longtail_MakeBlockIndex(
+    const struct Longtail_StoreIndex* store_index,
+    uint32_t block_index,
+    struct Longtail_BlockIndex* out_block_index);
 
 /*! @brief Writes a struct Longtail_StoreIndex to a byte buffer.
  *

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -27,6 +27,7 @@ struct Longtail_VersionIndex;
 struct Longtail_StoredBlock;
 struct Longtail_ContentIndex;
 struct Longtail_VersionDiff;
+struct Longtail_StoreIndex;
 
 ////////////// Longtail_API
 

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -1629,7 +1629,100 @@ LONGTAIL_EXPORT uint32_t Longtail_ContentIndex_GetVersion(const struct Longtail_
 LONGTAIL_EXPORT uint32_t Longtail_ContentIndex_GetHashAPI(const struct Longtail_ContentIndex* content_index);
 LONGTAIL_EXPORT uint64_t Longtail_ContentIndex_GetBlockCount(const struct Longtail_ContentIndex* content_index);
 LONGTAIL_EXPORT uint64_t Longtail_ContentIndex_GetChunkCount(const struct Longtail_ContentIndex* content_index);
-LONGTAIL_EXPORT TLongtail_Hash* Longtail_ContentIndex_BlockHashes(const struct Longtail_ContentIndex* content_index);
+LONGTAIL_EXPORT const TLongtail_Hash* Longtail_ContentIndex_BlockHashes(const struct Longtail_ContentIndex* content_index);
+
+struct Longtail_StoreIndex
+{
+    uint32_t* m_Version;
+    uint32_t* m_HashIdentifier;
+    uint32_t* m_BlockCount;             // Total number of blocks
+    uint32_t* m_ChunkCount;             // Total number of chunks across all blocks - chunk hashes may occur more than once
+    TLongtail_Hash* m_BlockHashes;      // [] m_BlockHashes is the hash of each block
+    TLongtail_Hash* m_ChunkHashes;      // [] For each m_BlockChunkCount[n] there are n consecutive chunk hashes in m_ChunkHashes[]
+    uint32_t* m_BlockChunksOffsets;     // [] m_BlockChunksOffsets[n] is the offset in m_ChunkBlockCount[] and m_ChunkHashes[]
+    uint32_t* m_BlockChunkCounts;       // [] m_BlockChunkCounts[n] is number of chunks in block m_BlockHash[n]
+    uint32_t* m_BlockTags;              // [] m_BlockTags is the tag for each block
+    uint32_t* m_ChunkSizes;             // [] m_ChunkSizes is the size of each chunk
+};
+
+LONGTAIL_EXPORT uint32_t Longtail_StoreIndex_GetVersion(const struct Longtail_StoreIndex* store_index);
+LONGTAIL_EXPORT uint32_t Longtail_StoreIndex_GetHashIdentifier(const struct Longtail_StoreIndex* store_index);
+LONGTAIL_EXPORT uint32_t Longtail_StoreIndex_GetBlockCount(const struct Longtail_StoreIndex* store_index);
+LONGTAIL_EXPORT uint32_t Longtail_StoreIndex_GetChunkCount(const struct Longtail_StoreIndex* store_index);
+LONGTAIL_EXPORT const TLongtail_Hash* Longtail_StoreIndex_GetBlockHashes(const struct Longtail_StoreIndex* store_index);
+LONGTAIL_EXPORT const TLongtail_Hash* Longtail_StoreIndex_GetChunkHashes(const struct Longtail_StoreIndex* store_index);
+LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetBlockChunksOffsets(const struct Longtail_StoreIndex* store_index);
+LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetBlockChunkCounts(const struct Longtail_StoreIndex* store_index);
+LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetBlockTags(const struct Longtail_StoreIndex* store_index);
+LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetChunkSizes(const struct Longtail_StoreIndex* store_index);
+
+LONGTAIL_EXPORT int Longtail_CreateStoreIndex(
+    uint32_t block_count,
+    struct Longtail_BlockIndex** block_indexes,
+    struct Longtail_StoreIndex** out_store_index);
+
+LONGTAIL_EXPORT int Longtail_MakeBlockIndex(
+    struct Longtail_StoreIndex* store_index,
+    uint32_t block_index,
+    struct Longtail_BlockIndex* out_block_index);
+
+/*! @brief Writes a struct Longtail_StoreIndex to a byte buffer.
+ *
+ * Serializes a struct Longtail_StoreIndex to a buffer which is allocated using Longtail_Alloc()
+ *
+ * @param[in] store_index   Pointer to an initialized struct Longtail_StoreIndex
+ * @param[out] out_buffer   Pointer to a buffer pointer intitialized on success
+ * @param[out] out_size     Pointer to a size variable intitialized on success
+ * @return                  Return code (errno style), zero on success
+ */
+LONGTAIL_EXPORT int Longtail_WriteStoreIndexToBuffer(
+    const struct Longtail_StoreIndex* store_index,
+    void** out_buffer,
+    size_t* out_size);
+
+/*! @brief Reads a struct Longtail_StoreIndex from a byte buffer.
+ *
+ * Deserializes a struct Longtail_StoreIndex from a buffer, the struct Longtail_StoreIndex is allocated using Longtail_Alloc()
+ *
+ * @param[in] buffer            Buffer containing the serialized struct Longtail_StoreIndex
+ * @param[in] size              Size of the buffer
+ * @param[out] out_store_index  Pointer to an struct Longtail_StoreIndex pointer
+ * @return                      Return code (errno style), zero on success
+ */
+LONGTAIL_EXPORT int Longtail_ReadStoreIndexFromBuffer(
+    const void* buffer,
+    size_t size,
+    struct Longtail_StoreIndex** out_store_index);
+
+/*! @brief Writes a struct Longtail_StoreIndex.
+ *
+ * Serializes a struct Longtail_StoreIndex to a file in a struct Longtail_StorageAPI at the specified path.
+ * The parent folder of the file path must exist.
+ *
+ * @param[in] storage_api   An initialized struct Longtail_StorageAPI
+ * @param[in] store_index   Pointer to an initialized struct Longtail_BlockIndex
+ * @param[in] path          A path in the storage api to store the stored block to
+ * @return                  Return code (errno style), zero on success
+ */
+LONGTAIL_EXPORT int Longtail_WriteStoreIndex(
+    struct Longtail_StorageAPI* storage_api,
+    struct Longtail_StoreIndex* store_index,
+    const char* path);
+
+/*! @brief Reads a struct Longtail_StoreIndex.
+ *
+ * Deserializes a struct Longtail_StoreIndex from a file in a struct Longtail_StorageAPI at the specified path.
+ * The file must exist.
+ *
+ * @param[in] storage_api       An initialized struct Longtail_StoreIndex
+ * @param[in] path              A path in the storage api to read the stored block from
+ * @param[out] out_store_index  Pointer to an struct Longtail_StoreIndex pointer
+ * @return                      Return code (errno style), zero on success
+ */
+LONGTAIL_EXPORT int Longtail_ReadStoreIndex(
+    struct Longtail_StorageAPI* storage_api,
+    const char* path,
+    struct Longtail_StoreIndex** out_store_index);
 
 struct Longtail_VersionIndex
 {

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -1663,6 +1663,8 @@ LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetBlockChunkCounts(const st
 LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetBlockTags(const struct Longtail_StoreIndex* store_index);
 LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetChunkSizes(const struct Longtail_StoreIndex* store_index);
 
+LONGTAIL_EXPORT size_t Longtail_GetStoreIndexSize(uint32_t block_count, uint32_t chunk_count);
+
 LONGTAIL_EXPORT int Longtail_CreateStoreIndexFromBlocks(
     uint32_t block_count,
     const struct Longtail_BlockIndex** block_indexes,
@@ -1677,6 +1679,14 @@ LONGTAIL_EXPORT int Longtail_MakeBlockIndex(
     const struct Longtail_StoreIndex* store_index,
     uint32_t block_index,
     struct Longtail_BlockIndex* out_block_index);
+
+LONGTAIL_EXPORT int Longtail_GetExistingContentIndex(
+    const struct Longtail_StoreIndex* store_index,
+    uint32_t chunk_count,
+    const TLongtail_Hash* chunks,
+    uint32_t max_block_size,
+    uint32_t max_chunks_per_block,
+    struct Longtail_ContentIndex** out_content_index);
 
 /*! @brief Writes a struct Longtail_StoreIndex to a byte buffer.
  *

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -1046,6 +1046,10 @@ LONGTAIL_EXPORT int Longtail_CreateContentIndexRaw(
     uint32_t max_chunks_per_block,
     struct Longtail_ContentIndex** out_content_index);
 
+LONGTAIL_EXPORT int Longtail_CreateContentIndexFromStoreIndex(
+    const struct Longtail_StoreIndex* store_index,
+    struct Longtail_ContentIndex** out_content_index);
+
 /*! @brief Writes a struct Longtail_ContentIndex to a byte buffer.
  *
  * Serializes a struct Longtail_ContentIndex to a buffer which is allocated using Longtail_Alloc()
@@ -1656,15 +1660,15 @@ LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetBlockChunkCounts(const st
 LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetBlockTags(const struct Longtail_StoreIndex* store_index);
 LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetChunkSizes(const struct Longtail_StoreIndex* store_index);
 
-LONGTAIL_EXPORT int Longtail_CreateStoreIndex(
+LONGTAIL_EXPORT int Longtail_CreateStoreIndexFromBlocks(
     uint32_t block_count,
-    struct Longtail_BlockIndex** block_indexes,
+    const struct Longtail_BlockIndex** block_indexes,
     struct Longtail_StoreIndex** out_store_index);
 
-LONGTAIL_EXPORT int Longtail_MakeBlockIndex(
-    struct Longtail_StoreIndex* store_index,
-    uint32_t block_index,
-    struct Longtail_BlockIndex* out_block_index);
+LONGTAIL_EXPORT int Longtail_MergeStoreIndex(
+    const struct Longtail_StoreIndex* local_store_index,
+    const struct Longtail_StoreIndex* remote_store_index,
+    struct Longtail_StoreIndex** out_store_index);
 
 /*! @brief Writes a struct Longtail_StoreIndex to a byte buffer.
  *

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -620,6 +620,82 @@ TEST(Longtail, Longtail_ContentIndex)
     SAFE_DISPOSE_API(hash_api);
 }
 
+TEST(Longtail, Longtail_CreateStoreIndexFromBlocks)
+{
+    struct Longtail_HashAPI* hash_api = Longtail_CreateMeowHashAPI();
+    ASSERT_NE((struct Longtail_HashAPI*)0, hash_api);
+    const uint64_t chunk_indexes[4] = {0, 1, 2, 3};
+    const TLongtail_Hash chunk_hashes[4] = {0xdeadbeeffeed5a17, 0xfeed5a17deadbeef, 0xaeed5a17deadbeea, 0xdaedbeeffeed5a57};
+    const uint32_t chunk_sizes[4] = {4711, 1147, 1137, 3219};
+    struct Longtail_BlockIndex* block_index1;
+    ASSERT_EQ(0, Longtail_CreateBlockIndex(
+        hash_api,
+        0x3127841,
+        2,
+        &chunk_indexes[0],
+        chunk_hashes,
+        chunk_sizes,
+        &block_index1));
+
+    struct Longtail_BlockIndex* block_index2;
+    ASSERT_EQ(0, Longtail_CreateBlockIndex(
+        hash_api,
+        0x3127841,
+        2,
+        &chunk_indexes[2],
+        chunk_hashes,
+        chunk_sizes,
+        &block_index2));
+
+    const struct Longtail_BlockIndex* block_indexes[2] = {block_index1, block_index2};
+
+    struct Longtail_StoreIndex* store_index;
+    ASSERT_EQ(0, Longtail_CreateStoreIndexFromBlocks(
+        2,
+        (const struct Longtail_BlockIndex**)block_indexes,
+        &store_index));
+
+    ASSERT_EQ(hash_api->GetIdentifier(hash_api), *store_index->m_HashIdentifier);
+    ASSERT_EQ(2, *store_index->m_BlockCount);
+    ASSERT_EQ(4, *store_index->m_ChunkCount);
+    ASSERT_EQ(*block_index1->m_BlockHash, store_index->m_BlockHashes[0]);
+    ASSERT_EQ(*block_index1->m_Tag, store_index->m_BlockTags[0]);
+    ASSERT_EQ(0, store_index->m_BlockChunksOffsets[0]);
+    ASSERT_EQ(2, store_index->m_BlockChunkCounts[0]);
+    ASSERT_EQ(*block_index2->m_BlockHash, store_index->m_BlockHashes[1]);
+    ASSERT_EQ(*block_index2->m_Tag, store_index->m_BlockTags[1]);
+    ASSERT_EQ(2, store_index->m_BlockChunksOffsets[1]);
+    ASSERT_EQ(2, store_index->m_BlockChunkCounts[1]);
+    ASSERT_EQ(chunk_hashes[0], store_index->m_ChunkHashes[0]);
+    ASSERT_EQ(chunk_hashes[1], store_index->m_ChunkHashes[1]);
+    ASSERT_EQ(chunk_hashes[2], store_index->m_ChunkHashes[2]);
+    ASSERT_EQ(chunk_hashes[3], store_index->m_ChunkHashes[3]);
+
+
+    struct Longtail_BlockIndex restored_block_indexes[2];
+    ASSERT_EQ(0, Longtail_MakeBlockIndex(store_index, 0, &restored_block_indexes[0]));
+    ASSERT_EQ(0, Longtail_MakeBlockIndex(store_index, 1, &restored_block_indexes[1]));
+
+    ASSERT_EQ(*block_index1->m_BlockHash, *restored_block_indexes[0].m_BlockHash);
+    ASSERT_EQ(*block_index1->m_HashIdentifier, *restored_block_indexes[0].m_HashIdentifier);
+    ASSERT_EQ(2, *restored_block_indexes[0].m_ChunkCount);
+    ASSERT_EQ(*block_index1->m_Tag, *restored_block_indexes[0].m_Tag);
+    ASSERT_EQ(chunk_hashes[0], restored_block_indexes[0].m_ChunkHashes[0]);
+    ASSERT_EQ(chunk_hashes[1], restored_block_indexes[0].m_ChunkHashes[1]);
+
+    ASSERT_EQ(*block_index2->m_BlockHash, *restored_block_indexes[1].m_BlockHash);
+    ASSERT_EQ(*block_index2->m_HashIdentifier, *restored_block_indexes[1].m_HashIdentifier);
+    ASSERT_EQ(2, *restored_block_indexes[1].m_ChunkCount);
+    ASSERT_EQ(*block_index2->m_Tag, *restored_block_indexes[1].m_Tag);
+    ASSERT_EQ(chunk_hashes[2], restored_block_indexes[1].m_ChunkHashes[0]);
+    ASSERT_EQ(chunk_hashes[3], restored_block_indexes[1].m_ChunkHashes[1]);
+
+    Longtail_Free(store_index);
+    Longtail_Free(block_index2);
+    Longtail_Free(block_index1);
+    SAFE_DISPOSE_API(hash_api);
+}
+
 TEST(Longtail, Longtail_RetargetContentIndex)
 {
 //    const char* assets_path = "";

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -766,7 +766,7 @@ TEST(Longtail, Longtail_MergeStoreIndex)
     SAFE_DISPOSE_API(hash_api);
 }
 
-TEST(Longtail, Longtail_RetargetContentIndex)
+TEST(Longtail, Longtail_RetargetContent)
 {
 //    const char* assets_path = "";
     const uint64_t asset_count = 5;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -763,6 +763,7 @@ TEST(Longtail, Longtail_MergeStoreIndex)
     Longtail_Free(store_index_local);
     Longtail_Free(block_index2);
     Longtail_Free(block_index1);
+    SAFE_DISPOSE_API(hash_api);
 }
 
 TEST(Longtail, Longtail_RetargetContentIndex)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -696,6 +696,75 @@ TEST(Longtail, Longtail_CreateStoreIndexFromBlocks)
     SAFE_DISPOSE_API(hash_api);
 }
 
+TEST(Longtail, Longtail_MergeStoreIndex)
+{
+    struct Longtail_HashAPI* hash_api = Longtail_CreateMeowHashAPI();
+    ASSERT_NE((struct Longtail_HashAPI*)0, hash_api);
+    const uint64_t chunk_indexes[5] = {0, 1, 2, 3, 4};
+    const TLongtail_Hash chunk_hashes[5] = {0xdeadbeeffeed5a17, 0xfeed5a17deadbeef, 0xaeed5a17deadbeea, 0xdaedbeeffeed5a57, 0xfeed5a17deadbeef};
+    const uint32_t chunk_sizes[5] = {4711, 1147, 1137, 3219, 1147};
+    struct Longtail_BlockIndex* block_index1;
+    ASSERT_EQ(0, Longtail_CreateBlockIndex(
+        hash_api,
+        0x3127841,
+        2,
+        &chunk_indexes[0],
+        chunk_hashes,
+        chunk_sizes,
+        &block_index1));
+
+    struct Longtail_BlockIndex* block_index2;
+    ASSERT_EQ(0, Longtail_CreateBlockIndex(
+        hash_api,
+        0x3127841,
+        3,
+        &chunk_indexes[2],
+        chunk_hashes,
+        chunk_sizes,
+        &block_index2));
+
+    struct Longtail_StoreIndex* store_index_local;
+    ASSERT_EQ(0, Longtail_CreateStoreIndexFromBlocks(
+        1,
+        (const struct Longtail_BlockIndex** )&block_index1,
+        &store_index_local));
+
+    struct Longtail_StoreIndex* store_index_remote;
+    ASSERT_EQ(0, Longtail_CreateStoreIndexFromBlocks(
+        1,
+        (const struct Longtail_BlockIndex** )&block_index2,
+        &store_index_remote));
+
+    struct Longtail_StoreIndex* store_index;
+    ASSERT_EQ(0, Longtail_MergeStoreIndex(
+        store_index_local,
+        store_index_remote,
+        &store_index));
+
+    ASSERT_EQ(hash_api->GetIdentifier(hash_api), *store_index->m_HashIdentifier);
+    ASSERT_EQ(2, *store_index->m_BlockCount);
+    ASSERT_EQ(5, *store_index->m_ChunkCount);
+    ASSERT_EQ(*block_index1->m_BlockHash, store_index->m_BlockHashes[0]);
+    ASSERT_EQ(*block_index1->m_Tag, store_index->m_BlockTags[0]);
+    ASSERT_EQ(0, store_index->m_BlockChunksOffsets[0]);
+    ASSERT_EQ(2, store_index->m_BlockChunkCounts[0]);
+    ASSERT_EQ(*block_index2->m_BlockHash, store_index->m_BlockHashes[1]);
+    ASSERT_EQ(*block_index2->m_Tag, store_index->m_BlockTags[1]);
+    ASSERT_EQ(2, store_index->m_BlockChunksOffsets[1]);
+    ASSERT_EQ(3, store_index->m_BlockChunkCounts[1]);
+    ASSERT_EQ(chunk_hashes[0], store_index->m_ChunkHashes[0]);
+    ASSERT_EQ(chunk_hashes[1], store_index->m_ChunkHashes[1]);
+    ASSERT_EQ(chunk_hashes[2], store_index->m_ChunkHashes[2]);
+    ASSERT_EQ(chunk_hashes[3], store_index->m_ChunkHashes[3]);
+    ASSERT_EQ(chunk_hashes[4], store_index->m_ChunkHashes[1]);
+
+    Longtail_Free(store_index);
+    Longtail_Free(store_index_remote);
+    Longtail_Free(store_index_local);
+    Longtail_Free(block_index2);
+    Longtail_Free(block_index1);
+}
+
 TEST(Longtail, Longtail_RetargetContentIndex)
 {
 //    const char* assets_path = "";


### PR DESCRIPTION
- **API CHANGE** `Longtail_ContentIndex_BlockHashes` now returns `const TLongtail_Hash*`
- **ADDED** `struct Longtail_StoreIndex` contaning all info in a set of block indexes - chunk duplicates allowed. Accessor functions
- **ADDED** Functions for `struct Longtail_StoreIndex`
  - `Longtail_GetStoreIndexSize`
  - `Longtail_CreateStoreIndexFromBlocks`
  - `Longtail_MergeStoreIndex`
  - `Longtail_MakeBlockIndex`
  - `Longtail_GetExistingContentIndex`
  - `Longtail_WriteStoreIndexToBuffer`
  - `Longtail_ReadStoreIndexFromBuffer`
  - `Longtail_WriteStoreIndex`
  - `Longtail_ReadStoreIndex`
- **CHANGED** FSBlockStore now uses `struct Longtail_StoreIndex` instead of `struct Longtail_ContentIndex`
