### PR TITLE
Fix/getexistingcontent usage

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -122,7 +122,8 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           # Changes in this Release
-          - **FIX** `Longtail_GetExistingContentIndex` now correctly sorts blocks and keeps order of blocks when usage is equal
+          - **FIX** `Longtail_GetExistingContentIndex` always sorts blocks based on usage
+          - **FIX** `LRUBlockStoreAPI` safely handles refresh of blocks on dispose
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/lib/lrublockstore/longtail_lrublockstore.c
+++ b/lib/lrublockstore/longtail_lrublockstore.c
@@ -128,7 +128,9 @@ static void LRUBlockStore_CompleteRequest(struct LRUBlockStoreAPI* lrublockstore
 
 int LRUStoredBlock_Dispose(struct Longtail_StoredBlock* stored_block)
 {
+    LONGTAIL_FATAL_ASSERT(stored_block != 0, return EINVAL)
     struct LRUStoredBlock* b = (struct LRUStoredBlock*)stored_block;
+    TLongtail_Hash block_hash = *stored_block->m_BlockIndex->m_BlockHash;
     int32_t ref_count = Longtail_AtomicAdd32(&b->m_RefCount, -1);
     if (ref_count > 1)
     {
@@ -140,7 +142,7 @@ int LRUStoredBlock_Dispose(struct Longtail_StoredBlock* stored_block)
         // We dipped down to just our LRU ref count - see if it is still around and refresh LRU position if so
         Longtail_LockSpinLock(api->m_Lock);
         intptr_t tmp;
-        intptr_t find_ptr = hmgeti_ts(api->m_BlockHashToLRUStoredBlock, *stored_block->m_BlockIndex->m_BlockHash, tmp);
+        intptr_t find_ptr = hmgeti_ts(api->m_BlockHashToLRUStoredBlock, block_hash, tmp);
         if (find_ptr == -1)
         {
             Longtail_UnlockSpinLock(api->m_Lock);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -868,12 +868,12 @@ TEST(Longtail, Longtail_GetExistingContentIndex)
         5,
         &all_blocks));
     ASSERT_EQ(6, *all_blocks->m_BlockCount);
-    ASSERT_EQ(*block_indexes[0]->m_BlockHash, all_blocks->m_BlockHashes[0]);
-    ASSERT_EQ(*block_indexes[1]->m_BlockHash, all_blocks->m_BlockHashes[1]);
-    ASSERT_EQ(*block_indexes[2]->m_BlockHash, all_blocks->m_BlockHashes[2]);
-    ASSERT_EQ(*block_indexes[3]->m_BlockHash, all_blocks->m_BlockHashes[3]);
-    ASSERT_EQ(*block_indexes[4]->m_BlockHash, all_blocks->m_BlockHashes[4]);
-    ASSERT_EQ(*block_indexes[5]->m_BlockHash, all_blocks->m_BlockHashes[5]);
+    ASSERT_EQ(*block_indexes[4]->m_BlockHash, all_blocks->m_BlockHashes[0]);
+    ASSERT_EQ(*block_indexes[2]->m_BlockHash, all_blocks->m_BlockHashes[1]);
+    ASSERT_EQ(*block_indexes[3]->m_BlockHash, all_blocks->m_BlockHashes[2]);
+    ASSERT_EQ(*block_indexes[1]->m_BlockHash, all_blocks->m_BlockHashes[3]);
+    ASSERT_EQ(*block_indexes[5]->m_BlockHash, all_blocks->m_BlockHashes[4]);
+    ASSERT_EQ(*block_indexes[0]->m_BlockHash, all_blocks->m_BlockHashes[5]);
     Longtail_Free(all_blocks);
 
     struct Longtail_ContentIndex* all_full_blocks;


### PR DESCRIPTION
**FIX** `Longtail_GetExistingContentIndex` always sorts blocks based on usage
**FIX** `LRUBlockStoreAPI` safely handles refresh of blocks on dispose
