### PR TITLE
Fix Longtail_InitContentIndex

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -106,6 +106,8 @@ jobs:
           # Changes in this Release
           - **FIX** Build script can be run from anywhere
           - **ADDED** Build script for executables now have extra option `run` to run the executable after build
+          - **API CHANGE** Longtail_InitContentIndex returns an initialized Longtail_ContentIndex from uninitialized memory
+          - **FIX** Longtail_ContentIndex no longer initialized from uninitialized memory
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -992,22 +992,18 @@ LONGTAIL_EXPORT int Longtail_InitContentIndexFromData(
 
 /*! @brief Initialize content index.
  *
- * Initialize a struct Longtail_ContentIndex.
+ * Initialize a chunk of memory to a struct Longtail_ContentIndex.
  *
- * @param[in] content_index         Pointer to an uninitialized struct Longtail_VersionIndex
- * @param[in] data                  Pointer to a uninitialized contend index data
- * @param[in] data_size             Size of uninitialized contend index data
+ * @param[in] mem                   Pointer to memory to initialize, must be of at least Longtail_GetContentIndexSize(@p block_count, @ chunk_count) size
  * @param[in] hash_api              Hash API identifier
  * @param[in] max_block_size        Max block size
  * @param[in] max_chunks_per_block  Max chunks per block
  * @param[in] block_count           Block count
  * @param[in] chunk_count           Chunk count
- * @return                          Return code (errno style), zero on success
+ * @return                          An initialized struct Longtail_ContentIndex*, zero of failure
  */
-LONGTAIL_EXPORT int Longtail_InitContentIndex(
-    struct Longtail_ContentIndex* content_index,
-    void* data,
-    uint64_t data_size,
+LONGTAIL_EXPORT struct Longtail_ContentIndex* Longtail_InitContentIndex(
+    void* mem,
     uint32_t hash_api,
     uint32_t max_block_size,
     uint32_t max_chunks_per_block,


### PR DESCRIPTION
*API CHANGE* Longtail_InitContentIndex returns an initialized Longtail_ContentIndex from uninitialized memory
*FIXED* Longtail_ContentIndex no longer initialized from uninitialized memory