### PR TITLE
Change Longtail_PathFilter_IncludeFunc so it is always called for ent…

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -104,8 +104,7 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           # Changes in this Release
-          - **FIX** Chunks per block should add up to and including max_parallell_block_read_jobs
-          - **FIX** Collapse consecutive chunks when writing from blocks
+          - **CHANGED** `Longtail_PathFilter_IncludeFunc` gets called for the entire structure and will not skip directories that are excluded in the filter callback
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -1293,24 +1293,24 @@ static int RecurseTree(
                         asset_path = 0;
                         break;
                     }
-                    if (properties.m_IsDir)
+                }
+                if (properties.m_IsDir)
+                {
+                    if ((size_t)arrlen(full_search_paths) == arrcap(full_search_paths))
                     {
-                        if ((size_t)arrlen(full_search_paths) == arrcap(full_search_paths))
+                        if (folder_index > 0)
                         {
-                            if (folder_index > 0)
-                            {
-                                uint32_t unprocessed_count = (uint32_t)(arrlen(full_search_paths) - folder_index);
-                                memmove(full_search_paths, &full_search_paths[folder_index], sizeof(const char*) * unprocessed_count);
-                                arrsetlen(full_search_paths, unprocessed_count);
-                                memmove(relative_parent_paths, &relative_parent_paths[folder_index], sizeof(const char*) * unprocessed_count);
-                                arrsetlen(relative_parent_paths, unprocessed_count);
-                                folder_index = 0;
-                            }
+                            uint32_t unprocessed_count = (uint32_t)(arrlen(full_search_paths) - folder_index);
+                            memmove(full_search_paths, &full_search_paths[folder_index], sizeof(const char*) * unprocessed_count);
+                            arrsetlen(full_search_paths, unprocessed_count);
+                            memmove(relative_parent_paths, &relative_parent_paths[folder_index], sizeof(const char*) * unprocessed_count);
+                            arrsetlen(relative_parent_paths, unprocessed_count);
+                            folder_index = 0;
                         }
-                        arrput(full_search_paths, storage_api->ConcatPath(storage_api, full_search_path, properties.m_Name));
-                        arrput(relative_parent_paths, asset_path);
-                        asset_path = 0;
                     }
+                    arrput(full_search_paths, storage_api->ConcatPath(storage_api, full_search_path, properties.m_Name));
+                    arrput(relative_parent_paths, asset_path);
+                    asset_path = 0;
                 }
                 Longtail_Free(asset_path);
             }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2127,15 +2127,15 @@ TEST(Longtail, Longtail_TestGetFilesRecursively)
 
         static int IncludeFunc(struct Longtail_PathFilterAPI* path_filter_api, const char* root_path, const char* asset_path, const char* asset_name, int is_dir, uint64_t size, uint16_t permissions)
         {
-            if(!is_dir)
-            {
-                return 1;
-            }
-            if (strcmp(asset_path, "a/file") == 0)
-            {
+            // Exclude all assets that start with "a/file"
+            size_t lenpre = strlen("a/file"),
+            lenstr = strlen(asset_path);
+            if (lenstr < lenpre ? 0 : memcmp("a/file", asset_path, lenpre) == 0) {
                 return 0;
             }
-            return 1;
+
+            // Include all files regardless of where in hierarchy, but skip dirs
+            return is_dir ? 0 : 1;
         }
     } test_filter;
 
@@ -2145,7 +2145,7 @@ TEST(Longtail, Longtail_TestGetFilesRecursively)
     Longtail_FileInfos* filtered_file_infos;
     ASSERT_EQ(0, Longtail_GetFilesRecursively(storage, &test_filter.m_API, 0, 0, "", &filtered_file_infos));
     ASSERT_NE((Longtail_FileInfos*)0, filtered_file_infos);
-    ASSERT_EQ(12u, filtered_file_infos->m_Count);
+    ASSERT_EQ(8u, filtered_file_infos->m_Count);
     Longtail_Free(filtered_file_infos);
 
     SAFE_DISPOSE_API(storage);


### PR DESCRIPTION
Change Longtail_PathFilter_IncludeFunc so it is always called for entire directory structure even if the callback function says "exclude" for a folder.