### PR TITLE
Replace content index with store index everywhere

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -104,10 +104,47 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           # Changes in this Release
-          - **CHANGE** `Longtail_LookupTabke` now uses uint32_t for indexes/values
-          - **ADDED** `Longtail_CopyStoreIndex` and `Longtail_CopyBlockIndex`
-          - **FIX** Removed redundant tag array in `ChunkAssets`
-          - **ADDED** `lib/memtracer` to track memory usage
+          - **CHANGED API**
+            - `Longtail_AsyncGetExistingContentAPI`
+            - `Longtail_BlockStore_PreflightGetFunc`
+            - `Longtail_BlockStore_GetExistingContentFunc`
+            - `Longtail_GetRequiredChunkHashes`
+            - `Longtail_WriteContent`
+            - `Longtail_WriteContent`
+            - `Longtail_CreateMissingContent`
+            - `Longtail_GetMissingChunks`
+            - `Longtail_AddContentIndex`
+            - `Longtail_CreateVersionDiff`
+            - `Longtail_ChangeVersion`
+            - `Longtail_InitBlockIndexFromData`
+          - **REMOVED API** Remove all `Longtail_ContentIndex` types and functions
+            - `struct Longtail_ContentIndex`
+            - `Longtail_GetContentIndexDataSize`
+            - `Longtail_GetContentIndexSize`
+            - `Longtail_InitContentIndexFromData`
+            - `Longtail_InitContentIndex`
+            - `Longtail_CreateContentIndexFromBlocks`
+            - `Longtail_CreateContentIndex`
+            - `Longtail_CreateContentIndexRaw`
+            - `Longtail_CreateContentIndexFromStoreIndex`
+            - `Longtail_WriteContentIndexToBuffer`
+            - `Longtail_ReadContentIndexFromBuffer`
+            - `Longtail_WriteContentIndex`
+            - `Longtail_ReadContentIndex`
+            - `Longtail_MergeContentIndex`
+            - `Longtail_ValidateContent`
+            - `Longtail_ValidateVersion`
+            - `Longtail_ContentIndex_GetVersion`
+            - `Longtail_ContentIndex_GetHashAPI`
+            - `Longtail_ContentIndex_GetBlockCount`
+            - `Longtail_ContentIndex_GetChunkCount`
+            - `Longtail_CreateStoreIndexFromContentIndex`
+            - `Longtail_GetExistingContentIndex`
+          - **ADDED API**
+            - `Longtail_CreateStoreIndex`
+            - `Longtail_GetExistingStoreIndex`
+            - `Longtail_ValidateStore`
+          - **REMOVED** `--version-content-index-path` option has been removed from command line tool
         draft: false
         prerelease: true
     - name: Download Linux artifacts

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -148,6 +148,7 @@ jobs:
             - `Longtail_VersionIndex_GetChunkSizes`
             - `Longtail_VersionIndex_GetChunkTags`
           - **REMOVED** `--version-content-index-path` option has been removed from command line tool
+          - **CHANGED** MemStorageAPI uses murmur3_32 instead of fnv1 to avoid hash collisions
         draft: false
         prerelease: true
     - name: Download Linux artifacts

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -144,6 +144,9 @@ jobs:
             - `Longtail_CreateStoreIndex`
             - `Longtail_GetExistingStoreIndex`
             - `Longtail_ValidateStore`
+            - `Longtail_VersionIndex_GetChunkHashes`
+            - `Longtail_VersionIndex_GetChunkSizes`
+            - `Longtail_StoreIndex_GetChunkTags`
           - **REMOVED** `--version-content-index-path` option has been removed from command line tool
         draft: false
         prerelease: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -146,7 +146,7 @@ jobs:
             - `Longtail_ValidateStore`
             - `Longtail_VersionIndex_GetChunkHashes`
             - `Longtail_VersionIndex_GetChunkSizes`
-            - `Longtail_StoreIndex_GetChunkTags`
+            - `Longtail_VersionIndex_GetChunkTags`
           - **REMOVED** `--version-content-index-path` option has been removed from command line tool
         draft: false
         prerelease: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -104,13 +104,6 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           # Changes in this Release
-          - **CHANGED** Reworked/simplified logic in MergeStoreIndex
-          - **CHANGED** Sounder hash identifier check in Longtail_MergeStoreIndex()
-          - **FIX** Test for CopyBlockIndex
-          - **FIX** Test for CopyStoreIndex
-          - **FIX** Don't assume stuff about memory layout of StoreIndex and BlockIndex
-          - **FIX** Graceful fail instead of assert on bad store index
-          - **FIX** Use uint64_t for stats in memtracer (fixes print formatting warnings)
           - **CHANGED API**
             - `Longtail_AsyncGetExistingContentAPI`
             - `Longtail_BlockStore_PreflightGetFunc`

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -109,7 +109,7 @@ jobs:
           - **FIX** Removed redundant tag array in `ChunkAssets`
           - **ADDED** `lib/memtracer` to track memory usage
         draft: false
-        prerelease: false
+        prerelease: true
     - name: Download Linux artifacts
       uses: actions/download-artifact@v1
       with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -150,7 +150,7 @@ jobs:
           - **REMOVED** `--version-content-index-path` option has been removed from command line tool
           - **CHANGED** MemStorageAPI uses murmur3_32 instead of fnv1 to avoid hash collisions
         draft: false
-        prerelease: true
+        prerelease: false
     - name: Download Linux artifacts
       uses: actions/download-artifact@v1
       with:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are targets for dynamic libaries (.so and .dll) in `shared_lib` and static
 # Concepts
 
 ## "Zero-parse" data formats
-The format for the data is stored in a "zero-parse" format - as long as the CPU architecture is little-endian, writing or reading one of the data formats - VersionIndex, ContentIndex or ContentBlock is just a matter of reading it into a chunk of memory and can be used in place. There are no pointers or complex data types (unless you count compression of the ContentBlock chunk data).
+The format for the data is stored in a "zero-parse" format - as long as the CPU architecture is little-endian, writing or reading one of the data formats - VersionIndex, StoreIndex or StoredBlock is just a matter of reading it into a chunk of memory and can be used in place. There are no pointers or complex data types (unless you count compression of the StoredBlock chunk data).
 
 ## Abstracted platform
 The core of the library is in the `src` folder and it defines a set of APIs that it need to operate. Each API is a structure with a number of C style function callbacks.
@@ -76,7 +76,7 @@ Currently there are:
 Longtail also borrows the chunking algorithm used to split up assets into chunks from the casync project by Lennart Poettering (https://github.com/systemd/casync).
 
 ## Content Adressable Storage
-Kinda, but not really - it started out that way but for various reasons it is only so in an indirect way, you can't get directly from a chunk hash to where it is located without going through a content index.
+Kinda, but not really - it started out that way but for various reasons it is only so in an indirect way, you can't get directly from a chunk hash to where it is located without going through a store index.
 
 Each chunk of data only contains one asset at most - one asset can be spread across multiple chunks. To make the store not suffer from a huge amount of small files chunks are bundled into blocks.
 
@@ -90,23 +90,23 @@ The version index in itself *does not* contain any of the data of the assets, it
 
 A version index is a particular version of a collection of assets, either a complete set of assets or a subset. Version indexes can be combined or updated/overriden.
 
-This is the "manifest" of a part of a game (or other) content- Small, efficient and easy to diff and make patches as well as easy to extend or replace with new asset data.
+This is the "manifest" of a part of a game (or other) content- Small, efficient and easy to diff and make patches from, as well as easy to extend or replace with new asset data.
 
 A version index can easily be constructed from a set of files/folders.
 
-## Content Block
-A content block contains one or more `chunks` of data with minimal meta data such as compress/uncompressed size and the hash of the uncompressed data of each chunk. Then Content Block is identified by a combined hash of all the chunk hashes inside the block.
+## Stored Block
+A stored block contains one or more `chunks` of data with minimal meta data such as compress/uncompressed size and the hash of the uncompressed data of each chunk. Then stored block is identified by a combined hash of all the chunk hashes inside the block.
 
-## Content Index
-A content index is a collection of ContentBlocks. This content index is used via the Version Index to reconstruct assets to a path.
+## Store Index
+A store index is a collection of Content Blocks indexes. This store index is used via the Version Index to reconstruct assets to a path.
 
-A content index can easily be constructed from a set of content blocks or you can create it based on a Version Index.
+A store index can easily be constructed from a set of content blocks or you can create it based on a Version Index.
 
 ## Version Diff
 Represents the difference between two Version Indexes - it contains which asset paths was created, modfied or deleted. 
 
 # So, what can it do?
-It can scan a folder on the file system, hash it and chunk it up, create content blocks and content index for the data.
+It can scan a folder on the file system, hash it and chunk it up, create content blocks and store index for the data.
 
 It can create a diff between one folder and another, find out which chunks it needs to go between said version and apply the change to a folder. It can write one version to a *new* folder or it can *update* an existing folder.
 

--- a/cmd/main.c
+++ b/cmd/main.c
@@ -335,7 +335,6 @@ int UpSync(
     const char* source_path,
     const char* optional_source_index_path,
     const char* target_index_path,
-    const char* optional_target_version_content_index_path,
     uint32_t target_chunk_size,
     uint32_t target_block_size,
     uint32_t max_chunks_per_block,
@@ -348,7 +347,6 @@ int UpSync(
         LONGTAIL_LOGFIELD(source_path, "%s"),
         LONGTAIL_LOGFIELD(optional_source_index_path, "%p"),
         LONGTAIL_LOGFIELD(target_index_path, "%s"),
-        LONGTAIL_LOGFIELD(optional_target_version_content_index_path, "%p"),
         LONGTAIL_LOGFIELD(target_chunk_size, "%u"),
         LONGTAIL_LOGFIELD(target_block_size, "%u"),
         LONGTAIL_LOGFIELD(max_chunks_per_block, "%u"),
@@ -577,31 +575,6 @@ int UpSync(
         SAFE_DISPOSE_API(job_api);
         Longtail_Free((char*)storage_path);
         return err;
-    }
-
-    if (optional_target_version_content_index_path)
-    {
-        err = Longtail_WriteContentIndex(
-            storage_api,
-            version_local_content_index,
-            optional_target_version_content_index_path);
-        if (err)
-        {
-            LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to write version content index for `%s` to `%s`, %d", source_path, optional_target_version_content_index_path, err);
-            Longtail_Free(version_local_content_index);
-            Longtail_Free(remote_missing_content_index);
-            Longtail_Free(existing_remote_content_index);
-            Longtail_Free(source_version_index);
-            SAFE_DISPOSE_API(chunker_api);
-            SAFE_DISPOSE_API(store_block_store_api);
-            SAFE_DISPOSE_API(store_block_fsstore_api);
-            SAFE_DISPOSE_API(storage_api);
-            SAFE_DISPOSE_API(compression_registry);
-            SAFE_DISPOSE_API(hash_registry);
-            SAFE_DISPOSE_API(job_api);
-            Longtail_Free((char*)storage_path);
-            return err;
-        }
     }
 
     err = Longtail_WriteVersionIndex(
@@ -1621,14 +1594,12 @@ int main(int argc, char** argv)
         const char* source_path = NormalizePath(source_path_raw);
         const char* source_index = source_index_raw ? NormalizePath(source_index_raw) : 0;
         const char* target_path = NormalizePath(target_path_raw);
-        const char* optional_target_version_content_index_path = optional_version_content_index_path_raw ? NormalizePath(optional_version_content_index_path_raw) : 0;
 
         err = UpSync(
             storage_uri_raw,
             source_path,
             source_index,
             target_path,
-            optional_target_version_content_index_path,
             target_chunk_size,
             target_block_size,
             max_chunks_per_block,

--- a/cmd/main.c
+++ b/cmd/main.c
@@ -309,7 +309,7 @@ static void AsyncGetExistingContentComplete_Dispose(struct AsyncGetExistingConte
     Longtail_Free(api->m_NotifySema);
 }
 
-static int SyncGetExistingContent(struct Longtail_BlockStoreAPI* block_store, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_StoreIndex** out_store_index)
+static int SyncGetExistingContent(struct Longtail_BlockStoreAPI* block_store, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_StoreIndex** out_store_index)
 {
     struct AsyncGetExistingContentComplete retarget_store_index_complete;
     AsyncGetExistingContentComplete_Init(&retarget_store_index_complete);
@@ -856,7 +856,7 @@ int DownSync(
         return 0;
     }
 
-    uint64_t required_chunk_count;
+    uint32_t required_chunk_count;
     TLongtail_Hash* required_chunk_hashes = (TLongtail_Hash*)Longtail_Alloc(0, sizeof(TLongtail_Hash) * (*source_version_index->m_ChunkCount));
     err = Longtail_GetRequiredChunkHashes(
             source_version_index,

--- a/cmd/main.c
+++ b/cmd/main.c
@@ -279,14 +279,14 @@ struct AsyncGetExistingContentComplete
     struct Longtail_AsyncGetExistingContentAPI m_API;
     HLongtail_Sema m_NotifySema;
     int m_Err;
-    struct Longtail_ContentIndex* m_ContentIndex;
+    struct Longtail_StoreIndex* m_StoreIndex;
 };
 
-static void AsyncGetExistingContentComplete_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err)
+static void AsyncGetExistingContentComplete_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_StoreIndex* store_index, int err)
 {
     struct AsyncGetExistingContentComplete* cb = (struct AsyncGetExistingContentComplete*)async_complete_api;
     cb->m_Err = err;
-    cb->m_ContentIndex = content_index;
+    cb->m_StoreIndex = store_index;
     Longtail_PostSema(cb->m_NotifySema, 1);
 }
 
@@ -300,7 +300,7 @@ static void AsyncGetExistingContentComplete_Init(struct AsyncGetExistingContentC
     api->m_Err = EINVAL;
     api->m_API.m_API.Dispose = 0;
     api->m_API.OnComplete = AsyncGetExistingContentComplete_OnComplete;
-    api->m_ContentIndex = 0;
+    api->m_StoreIndex = 0;
     Longtail_CreateSema(Longtail_Alloc(0, Longtail_GetSemaSize()), 0, &api->m_NotifySema);
 }
 static void AsyncGetExistingContentComplete_Dispose(struct AsyncGetExistingContentComplete* api)
@@ -309,24 +309,24 @@ static void AsyncGetExistingContentComplete_Dispose(struct AsyncGetExistingConte
     Longtail_Free(api->m_NotifySema);
 }
 
-static int SyncGetExistingContent(struct Longtail_BlockStoreAPI* block_store, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_ContentIndex** out_content_index)
+static int SyncGetExistingContent(struct Longtail_BlockStoreAPI* block_store, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_StoreIndex** out_store_index)
 {
-    struct AsyncGetExistingContentComplete retarget_content_index_complete;
-    AsyncGetExistingContentComplete_Init(&retarget_content_index_complete);
-    int err = block_store->GetExistingContent(block_store, chunk_count, chunk_hashes, min_block_usage_percent, &retarget_content_index_complete.m_API);
+    struct AsyncGetExistingContentComplete retarget_store_index_complete;
+    AsyncGetExistingContentComplete_Init(&retarget_store_index_complete);
+    int err = block_store->GetExistingContent(block_store, chunk_count, chunk_hashes, min_block_usage_percent, &retarget_store_index_complete.m_API);
     if (err)
     {
         return err;
     }
-    AsyncGetExistingContentComplete_Wait(&retarget_content_index_complete);
-    err = retarget_content_index_complete.m_Err;
-    struct Longtail_ContentIndex* content_index =  retarget_content_index_complete.m_ContentIndex;
-    AsyncGetExistingContentComplete_Dispose(&retarget_content_index_complete);
+    AsyncGetExistingContentComplete_Wait(&retarget_store_index_complete);
+    err = retarget_store_index_complete.m_Err;
+    struct Longtail_StoreIndex* store_index =  retarget_store_index_complete.m_StoreIndex;
+    AsyncGetExistingContentComplete_Dispose(&retarget_store_index_complete);
     if (err)
     {
         return err;
     }
-    *out_content_index = content_index;
+    *out_store_index = store_index;
     return 0;
 }
 
@@ -472,16 +472,16 @@ int UpSync(
         }
     }
 
-    struct Longtail_ContentIndex* existing_remote_content_index;
+    struct Longtail_StoreIndex* existing_remote_store_index;
     err = SyncGetExistingContent(
         store_block_store_api,
         *source_version_index->m_ChunkCount,
         source_version_index->m_ChunkHashes,
         min_block_usage_percent,
-        &existing_remote_content_index);
+        &existing_remote_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create missing content index %d", err);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create missing store index %d", err);
         Longtail_Free(source_version_index);
         SAFE_DISPOSE_API(chunker_api);
         SAFE_DISPOSE_API(store_block_store_api);
@@ -494,18 +494,18 @@ int UpSync(
         return err;
     }
 
-    struct Longtail_ContentIndex* remote_missing_content_index;
+    struct Longtail_StoreIndex* remote_missing_store_index;
     err = Longtail_CreateMissingContent(
         hash_api,
-        existing_remote_content_index,
+        existing_remote_store_index,
         source_version_index,
-        *existing_remote_content_index->m_MaxBlockSize,
-        *existing_remote_content_index->m_MaxChunksPerBlock,
-        &remote_missing_content_index);
+        target_block_size,
+        max_chunks_per_block,
+        &remote_missing_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create missing content index %d", err);
-        Longtail_Free(existing_remote_content_index);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create missing store index %d", err);
+        Longtail_Free(existing_remote_store_index);
         Longtail_Free(source_version_index);
         SAFE_DISPOSE_API(chunker_api);
         SAFE_DISPOSE_API(store_block_store_api);
@@ -528,7 +528,7 @@ int UpSync(
             progress,
             0,
             0,
-            remote_missing_content_index,
+            remote_missing_store_index,
             source_version_index,
             source_path);
         SAFE_DISPOSE_API(progress);
@@ -540,8 +540,8 @@ int UpSync(
 
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create content blocks for `%s` to `%s`, %d", source_path, storage_uri_raw, err);
-        Longtail_Free(existing_remote_content_index);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create store blocks for `%s` to `%s`, %d", source_path, storage_uri_raw, err);
+        Longtail_Free(existing_remote_store_index);
         Longtail_Free(source_version_index);
         SAFE_DISPOSE_API(chunker_api);
         SAFE_DISPOSE_API(store_block_store_api);
@@ -554,17 +554,16 @@ int UpSync(
         return err;
     }
 
-    struct Longtail_ContentIndex* version_local_content_index;
-    err = Longtail_MergeContentIndex(
-        job_api,
-        existing_remote_content_index,
-        remote_missing_content_index,
-        &version_local_content_index);
+    struct Longtail_StoreIndex* version_local_store_index;
+    err = Longtail_MergeStoreIndex(
+        existing_remote_store_index,
+        remote_missing_store_index,
+        &version_local_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create version local content index %d", err);
-        Longtail_Free(remote_missing_content_index);
-        Longtail_Free(existing_remote_content_index);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create version local store index %d", err);
+        Longtail_Free(remote_missing_store_index);
+        Longtail_Free(existing_remote_store_index);
         Longtail_Free(source_version_index);
         SAFE_DISPOSE_API(chunker_api);
         SAFE_DISPOSE_API(store_block_store_api);
@@ -584,9 +583,9 @@ int UpSync(
     if (err)
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to write version index for `%s` to `%s`, %d", source_path, target_index_path, err);
-        Longtail_Free(version_local_content_index);
-        Longtail_Free(remote_missing_content_index);
-        Longtail_Free(existing_remote_content_index);
+        Longtail_Free(version_local_store_index);
+        Longtail_Free(remote_missing_store_index);
+        Longtail_Free(existing_remote_store_index);
         Longtail_Free(source_version_index);
         SAFE_DISPOSE_API(chunker_api);
         SAFE_DISPOSE_API(store_block_store_api);
@@ -599,9 +598,9 @@ int UpSync(
         return err;
     }
 
-    Longtail_Free(version_local_content_index);
-    Longtail_Free(remote_missing_content_index);
-    Longtail_Free(existing_remote_content_index);
+    Longtail_Free(version_local_store_index);
+    Longtail_Free(remote_missing_store_index);
+    Longtail_Free(existing_remote_store_index);
     Longtail_Free(source_version_index);
     SAFE_DISPOSE_API(chunker_api);
     SAFE_DISPOSE_API(store_block_store_api);
@@ -741,7 +740,7 @@ int DownSync(
             &file_infos);
         if (err)
         {
-            LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to scan version content from `%s`, %d", target_path, err);
+            LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to scan version store from `%s`, %d", target_path, err);
             Longtail_Free(source_version_index);
             SAFE_DISPOSE_API(chunker_api);
             SAFE_DISPOSE_API(store_block_store_api);
@@ -886,16 +885,16 @@ int DownSync(
         return err;
     }
 
-    struct Longtail_ContentIndex* required_version_content_index;
+    struct Longtail_StoreIndex* required_version_store_index;
     err = SyncGetExistingContent(
         store_block_store_api,
         required_chunk_count,
         required_chunk_hashes,
         0,
-        &required_version_content_index);
+        &required_version_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to retarget the content index to remote store `%s`, %d", storage_uri_raw, err);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to retarget the store index to remote store `%s`, %d", storage_uri_raw, err);
         Longtail_Free(required_chunk_hashes);
         Longtail_Free(version_diff);
         Longtail_Free(target_version_index);
@@ -928,7 +927,7 @@ int DownSync(
             progress,
             0,
             0,
-            required_version_content_index,
+            required_version_store_index,
             target_version_index,
             source_version_index,
             version_diff,
@@ -946,7 +945,7 @@ int DownSync(
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to update version `%s` from `%s` using `%s`, %d", target_path, source_path, storage_uri_raw, err);
         Longtail_Free(version_diff);
         Longtail_Free(target_version_index);
-        Longtail_Free(required_version_content_index);
+        Longtail_Free(required_version_store_index);
         Longtail_Free(source_version_index);
         SAFE_DISPOSE_API(chunker_api);
         SAFE_DISPOSE_API(store_block_store_api);
@@ -965,7 +964,7 @@ int DownSync(
 
     Longtail_Free(version_diff);
     Longtail_Free(target_version_index);
-    Longtail_Free(required_version_content_index);
+    Longtail_Free(required_version_store_index);
     Longtail_Free(source_version_index);
     SAFE_DISPOSE_API(chunker_api);
     SAFE_DISPOSE_API(store_block_store_api);
@@ -1040,16 +1039,16 @@ int ValidateVersionIndex(
         return err;
     }
 
-    struct Longtail_ContentIndex* block_store_content_index;
+    struct Longtail_StoreIndex* block_store_store_index;
     err = SyncGetExistingContent(
         store_block_api,
         *version_index->m_ChunkCount,
         version_index->m_ChunkHashes,
         0,
-        &block_store_content_index);
+        &block_store_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create retarget content index for version index `%s` to `%s`", storage_uri_raw, version_index_path, err);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create retarget store index for version index `%s` to `%s`", storage_uri_raw, version_index_path, err);
         Longtail_Free(version_index);
         SAFE_DISPOSE_API(store_block_api);
         SAFE_DISPOSE_API(storage_api);
@@ -1059,12 +1058,12 @@ int ValidateVersionIndex(
         return err;
     }
 
-    err = Longtail_ValidateContent(block_store_content_index, version_index);
+    err = Longtail_ValidateStore(block_store_store_index, version_index);
     if (err)
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Store `%s` does not have all the required chunks for %s, failed with %d", storage_uri_raw, version_index_path, err);
         Longtail_Free(version_index);
-        Longtail_Free(block_store_content_index);
+        Longtail_Free(block_store_store_index);
         SAFE_DISPOSE_API(store_block_api);
         SAFE_DISPOSE_API(storage_api);
         SAFE_DISPOSE_API(hash_registry);
@@ -1073,7 +1072,7 @@ int ValidateVersionIndex(
         return err;
     }
     Longtail_Free(version_index);
-    Longtail_Free(block_store_content_index);
+    Longtail_Free(block_store_store_index);
     SAFE_DISPOSE_API(store_block_api);
     SAFE_DISPOSE_API(storage_api);
     SAFE_DISPOSE_API(hash_registry);
@@ -1133,19 +1132,22 @@ int VersionIndex_ls(
     }
 
 
-    struct Longtail_ContentIndex* content_index;
-    err = Longtail_CreateContentIndex(
+    struct Longtail_StoreIndex* store_index;
+    err = Longtail_CreateStoreIndex(
         hash_api,
-        version_index,
+        *version_index->m_ChunkCount,
+        version_index->m_ChunkHashes,
+        version_index->m_ChunkSizes,
+        version_index->m_ChunkTags,
         1024*1024*1024,
         1024,
-        &content_index);
+        &store_index);
 
     struct Longtail_StorageAPI* block_store_fs = Longtail_CreateBlockStoreStorageAPI(
         hash_api,
         job_api,
         fake_block_store,
-        content_index,
+        store_index,
         version_index);
     if (err)
     {
@@ -1165,7 +1167,7 @@ int VersionIndex_ls(
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create file iteration for version index `%s`, failed with %d", version_index_path, err);
         SAFE_DISPOSE_API(block_store_fs);
-        Longtail_Free(content_index);
+        Longtail_Free(store_index);
         SAFE_DISPOSE_API(fake_block_store);
         SAFE_DISPOSE_API(fake_block_store_fs);
         SAFE_DISPOSE_API(storage_api);
@@ -1199,7 +1201,7 @@ int VersionIndex_ls(
     block_store_fs->CloseFind(block_store_fs, fs_iterator);
     
     SAFE_DISPOSE_API(block_store_fs);
-    Longtail_Free(content_index);
+    Longtail_Free(store_index);
     SAFE_DISPOSE_API(fake_block_store);
     SAFE_DISPOSE_API(fake_block_store_fs);
     SAFE_DISPOSE_API(storage_api);
@@ -1290,16 +1292,16 @@ int VersionIndex_cp(
         return err;
     }
 
-    struct Longtail_ContentIndex* block_store_content_index;
+    struct Longtail_StoreIndex* block_store_store_index;
     err = SyncGetExistingContent(
         store_block_store_api,
         *version_index->m_ChunkCount,
         version_index->m_ChunkHashes,
         0,
-        &block_store_content_index);
+        &block_store_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create retarget content index for version index `%s` to `%s`", storage_uri_raw, version_index_path, err);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create retarget store index for version index `%s` to `%s`", storage_uri_raw, version_index_path, err);
         SAFE_DISPOSE_API(store_block_store_api);
         SAFE_DISPOSE_API(lru_block_store_api);
         SAFE_DISPOSE_API(compress_block_store_api);
@@ -1314,11 +1316,11 @@ int VersionIndex_cp(
         return err;
     }
 
-    err = Longtail_ValidateContent(block_store_content_index, version_index);
+    err = Longtail_ValidateStore(block_store_store_index, version_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Store `%s` does not contain all the chunks needed for this version `%s`, Longtail_ValidateContent failed with %d", storage_uri_raw, source_path, err);
-        Longtail_Free(block_store_content_index);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Store `%s` does not contain all the chunks needed for this version `%s`, Longtail_ValidateStore failed with %d", storage_uri_raw, source_path, err);
+        Longtail_Free(block_store_store_index);
         SAFE_DISPOSE_API(store_block_store_api);
         SAFE_DISPOSE_API(lru_block_store_api);
         SAFE_DISPOSE_API(compress_block_store_api);
@@ -1337,12 +1339,12 @@ int VersionIndex_cp(
         hash_api,
         job_api,
         store_block_store_api,
-        block_store_content_index,
+        block_store_store_index,
         version_index);
     if (err)
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create file system for version index `%s`, failed with %d", version_index_path, err);
-        Longtail_Free(block_store_content_index);
+        Longtail_Free(block_store_store_index);
         SAFE_DISPOSE_API(store_block_store_api);
         SAFE_DISPOSE_API(lru_block_store_api);
         SAFE_DISPOSE_API(compress_block_store_api);
@@ -1363,7 +1365,7 @@ int VersionIndex_cp(
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to open file `%s` in version index `%s`, failed with %d", source_path, version_index_path, err);
         SAFE_DISPOSE_API(block_store_fs);
-        Longtail_Free(block_store_content_index);
+        Longtail_Free(block_store_store_index);
         SAFE_DISPOSE_API(store_block_store_api);
         SAFE_DISPOSE_API(lru_block_store_api);
         SAFE_DISPOSE_API(compress_block_store_api);
@@ -1384,7 +1386,7 @@ int VersionIndex_cp(
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to get size of file `%s` in version index `%s`, failed with %d", source_path, version_index_path, err);
         block_store_fs->CloseFile(block_store_fs, f);
         SAFE_DISPOSE_API(block_store_fs);
-        Longtail_Free(block_store_content_index);
+        Longtail_Free(block_store_store_index);
         SAFE_DISPOSE_API(store_block_store_api);
         SAFE_DISPOSE_API(lru_block_store_api);
         SAFE_DISPOSE_API(compress_block_store_api);
@@ -1405,7 +1407,7 @@ int VersionIndex_cp(
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to open file `%s`, failed with %d", target_path, err);
         block_store_fs->CloseFile(block_store_fs, f);
         SAFE_DISPOSE_API(block_store_fs);
-        Longtail_Free(block_store_content_index);
+        Longtail_Free(block_store_store_index);
         SAFE_DISPOSE_API(store_block_store_api);
         SAFE_DISPOSE_API(lru_block_store_api);
         SAFE_DISPOSE_API(compress_block_store_api);
@@ -1441,7 +1443,7 @@ int VersionIndex_cp(
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to get permissions of file `%s` in version index `%s`, failed with %d", source_path, version_index_path, err);
         SAFE_DISPOSE_API(block_store_fs);
-        Longtail_Free(block_store_content_index);
+        Longtail_Free(block_store_store_index);
         SAFE_DISPOSE_API(store_block_store_api);
         SAFE_DISPOSE_API(lru_block_store_api);
         SAFE_DISPOSE_API(compress_block_store_api);
@@ -1461,7 +1463,7 @@ int VersionIndex_cp(
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to set permissions of file `%s`, failed with %d", target_path, err);
         SAFE_DISPOSE_API(block_store_fs);
-        Longtail_Free(block_store_content_index);
+        Longtail_Free(block_store_store_index);
         SAFE_DISPOSE_API(store_block_store_api);
         SAFE_DISPOSE_API(lru_block_store_api);
         SAFE_DISPOSE_API(compress_block_store_api);
@@ -1477,7 +1479,7 @@ int VersionIndex_cp(
     }
 
     SAFE_DISPOSE_API(block_store_fs);
-    Longtail_Free(block_store_content_index);
+    Longtail_Free(block_store_store_index);
     SAFE_DISPOSE_API(store_block_store_api);
     SAFE_DISPOSE_API(lru_block_store_api);
     SAFE_DISPOSE_API(compress_block_store_api);
@@ -1538,7 +1540,7 @@ int main(int argc, char** argv)
     int err = 0;
     if (strcmp(command, "upsync") == 0){
         const char* storage_uri_raw = 0;
-        kgflags_string("storage-uri", 0, "URI for chunks and content index for store", true, &storage_uri_raw);
+        kgflags_string("storage-uri", 0, "URI for chunks and store index for store", true, &storage_uri_raw);
 
         const char* hasing_raw = 0;
         kgflags_string("hash-algorithm", "blake3", "Hashing algorithm: blake2, blake3, meow", false, &hasing_raw);
@@ -1551,9 +1553,6 @@ int main(int argc, char** argv)
 
         const char* target_path_raw = 0;
         kgflags_string("target-path", 0, "Target file path", true, &target_path_raw);
-
-        const char* optional_version_content_index_path_raw = 0;
-        kgflags_string("version-content-index-path", 0, "Optional path to store minimal content index for version", false, &optional_version_content_index_path_raw);
 
         const char* compression_raw = 0;
         kgflags_string("compression-algorithm", "zstd", "Compression algorithm: none, brotli, brotli_min, brotli_max, brotli_text, brotli_text_min, brotli_text_max, lz4, zstd, zstd_min, zstd_max", false, &compression_raw);
@@ -1614,7 +1613,7 @@ int main(int argc, char** argv)
     else if (strcmp(command, "downsync") == 0)
     {
         const char* storage_uri_raw = 0;
-        kgflags_string("storage-uri", 0, "URI for chunks and content index for store", true, &storage_uri_raw);
+        kgflags_string("storage-uri", 0, "URI for chunks and store index for store", true, &storage_uri_raw);
 
         const char* cache_path_raw = 0;
         kgflags_string("cache-path", 0, "Location for downloaded/cached blocks", false, &cache_path_raw);
@@ -1672,7 +1671,7 @@ int main(int argc, char** argv)
     else if (strcmp(command, "validate") == 0)
     {
         const char* storage_uri_raw = 0;
-        kgflags_string("storage-uri", 0, "URI for chunks and content index for store", true, &storage_uri_raw);
+        kgflags_string("storage-uri", 0, "URI for chunks and store index for store", true, &storage_uri_raw);
 
         const char* version_index_path_raw = 0;
         kgflags_string("version-index-path", 0, "Path to version index", true, &version_index_path_raw);
@@ -1742,7 +1741,7 @@ int main(int argc, char** argv)
     else if (strcmp(command, "cp") == 0)
     {
         const char* storage_uri_raw = 0;
-        kgflags_string("storage-uri", 0, "URI for chunks and content index for store", true, &storage_uri_raw);
+        kgflags_string("storage-uri", 0, "URI for chunks and store index for store", true, &storage_uri_raw);
 
         const char* cache_path_raw = 0;
         kgflags_string("cache-path", 0, "Location for downloaded/cached blocks", false, &cache_path_raw);

--- a/lib/blockstorestorage/longtail_blockstorestorage.c
+++ b/lib/blockstorestorage/longtail_blockstorestorage.c
@@ -1244,7 +1244,7 @@ static int BlockStoreStorageAPI_Init(
     LONGTAIL_VALIDATE_INPUT(ctx, out_storage_api != 0, return 0)
 
     struct BlockStoreStorageAPI* block_store_fs = (struct BlockStoreStorageAPI*)mem;
-    uint64_t content_index_chunk_count = *store_index->m_ChunkCount;
+    uint64_t store_index_chunk_count = *store_index->m_ChunkCount;
     uint32_t version_index_asset_count = *version_index->m_AssetCount;
 
     block_store_fs->m_API.m_API.Dispose = BlockStoreStorageAPI_Dispose;
@@ -1275,13 +1275,13 @@ static int BlockStoreStorageAPI_Init(
     block_store_fs->m_VersionIndex = version_index;
 
     char* p = (char*)&block_store_fs[1];
-    block_store_fs->m_ChunkHashToBlockIndexLookup = Longtail_LookupTable_Create(p, (uint32_t)content_index_chunk_count, 0);
-    p += Longtail_LookupTable_GetSize((uint32_t)content_index_chunk_count);
+    block_store_fs->m_ChunkHashToBlockIndexLookup = Longtail_LookupTable_Create(p, (uint32_t)store_index_chunk_count, 0);
+    p += Longtail_LookupTable_GetSize((uint32_t)store_index_chunk_count);
     block_store_fs->m_PathLookup = BlockStoreStorageAPI_CreatePathLookup(p, hash_api, version_index);
     p += GetPathEntriesSize(version_index_asset_count);
     block_store_fs->m_ChunkAssetOffsets = (uint64_t*)p;
 
-    const TLongtail_Hash* content_index_chunk_hashes = store_index->m_ChunkHashes;
+    const TLongtail_Hash* stire_index_chunk_hashes = store_index->m_ChunkHashes;
     uint32_t block_count = *store_index->m_BlockCount;
     for (uint32_t b = 0; b < block_count; ++b)
     {

--- a/lib/blockstorestorage/longtail_blockstorestorage.h
+++ b/lib/blockstorestorage/longtail_blockstorestorage.h
@@ -10,7 +10,7 @@ LONGTAIL_EXPORT extern struct Longtail_StorageAPI* Longtail_CreateBlockStoreStor
     struct Longtail_HashAPI* hash_api,
     struct Longtail_JobAPI* job_api,
     struct Longtail_BlockStoreAPI* block_store,
-    struct Longtail_ContentIndex* content_index,
+    struct Longtail_StoreIndex* store_index,
     struct Longtail_VersionIndex* version_index);
 
 #ifdef __cplusplus

--- a/lib/cacheblockstore/longtail_cacheblockstore.c
+++ b/lib/cacheblockstore/longtail_cacheblockstore.c
@@ -254,7 +254,7 @@ struct PreflightRetargetContext
 {
     struct Longtail_AsyncGetExistingContentAPI m_AsyncCompleteAPI;
     struct CacheBlockStoreAPI* m_CacheBlockStoreAPI;
-    uint64_t m_ChunkCount;
+    uint32_t m_ChunkCount;
     TLongtail_Hash* m_ChunkHashes;
 };
 
@@ -286,7 +286,7 @@ static void PreflightGet_GetExistingContentCompleteAPI_OnComplete(struct Longtai
         }
     }
 
-    uint64_t missing_chunk_count = 0;
+    uint32_t missing_chunk_count = 0;
     TLongtail_Hash* missing_chunk_hashes = (TLongtail_Hash*)Longtail_Alloc("CacheBlockStore", sizeof(TLongtail_Hash) * retarget_context->m_ChunkCount);
     if (!missing_chunk_hashes)
     {
@@ -328,12 +328,12 @@ static void PreflightGet_GetExistingContentCompleteAPI_OnComplete(struct Longtai
 
 static int CacheBlockStore_PreflightGet(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(block_store_api, "%p"),
-        LONGTAIL_LOGFIELD(chunk_count, "%" PRIu64),
+        LONGTAIL_LOGFIELD(chunk_count, "%u"),
         LONGTAIL_LOGFIELD(chunk_hashes, "%p")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_DEBUG)
 
@@ -617,7 +617,7 @@ struct RetargetContext_RetargetToRemote_Context
     struct CacheBlockStoreAPI* m_CacheBlockStoreAPI;
     struct Longtail_AsyncGetExistingContentAPI* m_RetargetAsyncCompleteAPI;
     struct Longtail_StoreIndex* m_LocalRetargettedStoreIndex;
-    uint64_t m_ChunkCount;
+    uint32_t m_ChunkCount;
     TLongtail_Hash* m_ChunkHashes;
 };
 
@@ -659,7 +659,7 @@ struct RetargetContext_RetargetToLocal_Context
     struct Longtail_AsyncGetExistingContentAPI m_AsyncCompleteAPI;
     struct CacheBlockStoreAPI* m_CacheBlockStoreAPI;
     struct Longtail_AsyncGetExistingContentAPI* m_RetargetAsyncCompleteAPI;
-    uint64_t m_ChunkCount;
+    uint32_t m_ChunkCount;
     TLongtail_Hash* m_ChunkHashes;
     uint32_t m_MinBlockUsagePercent;
 };
@@ -726,7 +726,7 @@ static void RetargetLocalContent_GetExistingContentCompleteAPI_OnComplete(struct
 
 static int CacheBlockStore_GetExistingContent(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes,
     uint32_t min_block_usage_percent,
     struct Longtail_AsyncGetExistingContentAPI* async_complete_api)

--- a/lib/cacheblockstore/longtail_cacheblockstore.c
+++ b/lib/cacheblockstore/longtail_cacheblockstore.c
@@ -258,11 +258,11 @@ struct PreflightRetargetContext
     TLongtail_Hash* m_ChunkHashes;
 };
 
-static void PreflightGet_GetExistingContentCompleteAPI_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err)
+static void PreflightGet_GetExistingContentCompleteAPI_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_StoreIndex* store_index, int err)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(async_complete_api, "%p"),
-        LONGTAIL_LOGFIELD(content_index, "%p"),
+        LONGTAIL_LOGFIELD(store_index, "%p"),
         LONGTAIL_LOGFIELD(err, "%d")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_DEBUG)
 
@@ -274,13 +274,13 @@ static void PreflightGet_GetExistingContentCompleteAPI_OnComplete(struct Longtai
         Longtail_Free(retarget_context);
         return;
     }
-    if (*content_index->m_ChunkCount > 0)
+    if (*store_index->m_ChunkCount > 0)
     {
-        err = api->m_LocalBlockStoreAPI->PreflightGet(api->m_LocalBlockStoreAPI, *content_index->m_ChunkCount, content_index->m_ChunkHashes);
+        err = api->m_LocalBlockStoreAPI->PreflightGet(api->m_LocalBlockStoreAPI, *store_index->m_ChunkCount, store_index->m_ChunkHashes);
         if (err)
         {
             LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "api->m_LocalBlockStoreAPI->PreflightGet() failed with %d", err)
-            Longtail_Free(content_index);
+            Longtail_Free(store_index);
             Longtail_Free(retarget_context);
             return;
         }
@@ -291,12 +291,12 @@ static void PreflightGet_GetExistingContentCompleteAPI_OnComplete(struct Longtai
     if (!missing_chunk_hashes)
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Longtail_Alloc() failed with %d", ENOMEM)
-        Longtail_Free(content_index);
+        Longtail_Free(store_index);
         Longtail_Free(retarget_context);
         return;
     }
     err = Longtail_GetMissingChunks(
-        content_index,
+        store_index,
         retarget_context->m_ChunkCount,
         retarget_context->m_ChunkHashes,
         &missing_chunk_count,
@@ -305,7 +305,7 @@ static void PreflightGet_GetExistingContentCompleteAPI_OnComplete(struct Longtai
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Longtail_GetMissingChunks() failed with %d", err)
         Longtail_Free(missing_chunk_hashes);
-        Longtail_Free(content_index);
+        Longtail_Free(store_index);
         Longtail_Free(retarget_context);
         return;
     }
@@ -316,13 +316,13 @@ static void PreflightGet_GetExistingContentCompleteAPI_OnComplete(struct Longtai
         {
             LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "api->m_RemoteBlockStoreAPI->PreflightGet() failed with %d", err)
             Longtail_Free(missing_chunk_hashes);
-            Longtail_Free(content_index);
+            Longtail_Free(store_index);
             Longtail_Free(retarget_context);
             return;
         }
     }
     Longtail_Free(missing_chunk_hashes);
-    Longtail_Free(content_index);
+    Longtail_Free(store_index);
     Longtail_Free(retarget_context);
 }
 
@@ -616,16 +616,16 @@ struct RetargetContext_RetargetToRemote_Context
     struct Longtail_AsyncGetExistingContentAPI m_AsyncCompleteAPI;
     struct CacheBlockStoreAPI* m_CacheBlockStoreAPI;
     struct Longtail_AsyncGetExistingContentAPI* m_RetargetAsyncCompleteAPI;
-    struct Longtail_ContentIndex* m_LocalRetargettedContentIndex;
+    struct Longtail_StoreIndex* m_LocalRetargettedStoreIndex;
     uint64_t m_ChunkCount;
     TLongtail_Hash* m_ChunkHashes;
 };
 
-static void RetargetRemoteContent_GetExistingContentCompleteAPI_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err)
+static void RetargetRemoteContent_GetExistingContentCompleteAPI_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_StoreIndex* store_index, int err)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(async_complete_api, "%p"),
-        LONGTAIL_LOGFIELD(content_index, "%p"),
+        LONGTAIL_LOGFIELD(store_index, "%p"),
         LONGTAIL_LOGFIELD(err, "%d")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_DEBUG)
 
@@ -637,20 +637,20 @@ static void RetargetRemoteContent_GetExistingContentCompleteAPI_OnComplete(struc
         Longtail_Free(retarget_context);
         return;
     }
-    struct Longtail_ContentIndex* merged_content_index;
-    err = Longtail_AddContentIndex(
-        retarget_context->m_LocalRetargettedContentIndex,
-        content_index,
-        &merged_content_index);
-    Longtail_Free(content_index);
-    Longtail_Free(retarget_context->m_LocalRetargettedContentIndex);
+    struct Longtail_StoreIndex* merged_store_index;
+    err = Longtail_MergeStoreIndex(
+        retarget_context->m_LocalRetargettedStoreIndex,
+        store_index,
+        &merged_store_index);
+    Longtail_Free(store_index);
+    Longtail_Free(retarget_context->m_LocalRetargettedStoreIndex);
     if (err)
     {
         retarget_context->m_RetargetAsyncCompleteAPI->OnComplete(retarget_context->m_RetargetAsyncCompleteAPI, 0, err);
         Longtail_Free(retarget_context);
         return;
     }
-    retarget_context->m_RetargetAsyncCompleteAPI->OnComplete(retarget_context->m_RetargetAsyncCompleteAPI, merged_content_index, 0);
+    retarget_context->m_RetargetAsyncCompleteAPI->OnComplete(retarget_context->m_RetargetAsyncCompleteAPI, merged_store_index, 0);
     Longtail_Free(retarget_context);
 }
 
@@ -664,11 +664,11 @@ struct RetargetContext_RetargetToLocal_Context
     uint32_t m_MinBlockUsagePercent;
 };
 
-static void RetargetLocalContent_GetExistingContentCompleteAPI_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err)
+static void RetargetLocalContent_GetExistingContentCompleteAPI_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_StoreIndex* store_index, int err)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(async_complete_api, "%p"),
-        LONGTAIL_LOGFIELD(content_index, "%p"),
+        LONGTAIL_LOGFIELD(store_index, "%p"),
         LONGTAIL_LOGFIELD(err, "%d")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_DEBUG)
 
@@ -683,14 +683,14 @@ static void RetargetLocalContent_GetExistingContentCompleteAPI_OnComplete(struct
     struct RetargetContext_RetargetToRemote_Context* retarget_remote_context = (struct RetargetContext_RetargetToRemote_Context*)Longtail_Alloc("CacheBlockStore", sizeof(struct RetargetContext_RetargetToRemote_Context) + (sizeof(TLongtail_Hash) * retarget_context->m_ChunkCount));
     retarget_remote_context->m_ChunkHashes = (TLongtail_Hash*)&retarget_remote_context[1];
     err = Longtail_GetMissingChunks(
-        content_index,
+        store_index,
         retarget_context->m_ChunkCount,
         retarget_context->m_ChunkHashes,
         &retarget_remote_context->m_ChunkCount,
         retarget_remote_context->m_ChunkHashes);
     if (err)
     {
-        Longtail_Free(content_index);
+        Longtail_Free(store_index);
         retarget_context->m_RetargetAsyncCompleteAPI->OnComplete(retarget_context->m_RetargetAsyncCompleteAPI, 0, err);
         Longtail_Free(retarget_context);
         return;
@@ -698,14 +698,14 @@ static void RetargetLocalContent_GetExistingContentCompleteAPI_OnComplete(struct
     if (retarget_remote_context->m_ChunkCount == 0)
     {
         Longtail_Free(retarget_remote_context);
-        retarget_context->m_RetargetAsyncCompleteAPI->OnComplete(retarget_context->m_RetargetAsyncCompleteAPI, content_index, 0);
+        retarget_context->m_RetargetAsyncCompleteAPI->OnComplete(retarget_context->m_RetargetAsyncCompleteAPI, store_index, 0);
         Longtail_Free(retarget_context);
         return;
     }
     retarget_remote_context->m_AsyncCompleteAPI.m_API.Dispose = 0;
     retarget_remote_context->m_AsyncCompleteAPI.OnComplete = RetargetRemoteContent_GetExistingContentCompleteAPI_OnComplete;
     retarget_remote_context->m_CacheBlockStoreAPI = api;
-    retarget_remote_context->m_LocalRetargettedContentIndex = content_index;
+    retarget_remote_context->m_LocalRetargettedStoreIndex = store_index;
     retarget_remote_context->m_RetargetAsyncCompleteAPI = retarget_context->m_RetargetAsyncCompleteAPI;
     err = api->m_RemoteBlockStoreAPI->GetExistingContent(
         api->m_RemoteBlockStoreAPI,
@@ -717,7 +717,7 @@ static void RetargetLocalContent_GetExistingContentCompleteAPI_OnComplete(struct
     {
         retarget_context->m_RetargetAsyncCompleteAPI->OnComplete(retarget_context->m_RetargetAsyncCompleteAPI, 0, err);
         Longtail_Free(retarget_remote_context);
-        Longtail_Free(content_index);
+        Longtail_Free(store_index);
         Longtail_Free(retarget_context);
         return;
     }

--- a/lib/compressblockstore/longtail_compressblockstore.c
+++ b/lib/compressblockstore/longtail_compressblockstore.c
@@ -240,7 +240,7 @@ static int CompressBlockStore_PutStoredBlock(
 
 static int CompressBlockStore_PreflightGet(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
@@ -453,7 +453,7 @@ static int CompressBlockStore_GetStoredBlock(
 
 static int CompressBlockStore_GetExistingContent(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes,
     uint32_t min_block_usage_percent,
     struct Longtail_AsyncGetExistingContentAPI* async_complete_api)

--- a/lib/fsblockstore/longtail_fsblockstore.c
+++ b/lib/fsblockstore/longtail_fsblockstore.c
@@ -963,24 +963,24 @@ static int FSBlockStore_GetExistingContent(
         return err;
     }
 
-    struct Longtail_ContentIndex* existing_content_index;
-    err = Longtail_GetExistingContentIndex(
+    struct Longtail_StoreIndex* existing_store_index;
+    err = Longtail_GetExistingStoreIndex(
         store_index,
         (uint32_t)chunk_count,
         chunk_hashes,
         min_block_usage_percent,
         fsblockstore_api->m_DefaultMaxBlockSize,
         fsblockstore_api->m_DefaultMaxChunksPerBlock,
-        &existing_content_index);
+        &existing_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Longtail_GetExistingContentIndex() failed with %d", err)
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Longtail_GetExistingStoreIndex() failed with %d", err)
         Longtail_AtomicAdd64(&fsblockstore_api->m_StatU64[Longtail_BlockStoreAPI_StatU64_GetExistingContent_FailCount], 1);
         Longtail_Free(store_index);
         return err;
     }
     Longtail_Free(store_index);
-    async_complete_api->OnComplete(async_complete_api, existing_content_index, 0);
+    async_complete_api->OnComplete(async_complete_api, existing_store_index, 0);
     return 0;
 }
 

--- a/lib/fsblockstore/longtail_fsblockstore.c
+++ b/lib/fsblockstore/longtail_fsblockstore.c
@@ -969,8 +969,6 @@ static int FSBlockStore_GetExistingContent(
         chunk_count,
         chunk_hashes,
         min_block_usage_percent,
-        fsblockstore_api->m_DefaultMaxBlockSize,
-        fsblockstore_api->m_DefaultMaxChunksPerBlock,
         &existing_store_index);
     if (err)
     {

--- a/lib/fsblockstore/longtail_fsblockstore.c
+++ b/lib/fsblockstore/longtail_fsblockstore.c
@@ -672,7 +672,7 @@ static int FSBlockStore_PutStoredBlock(
 
 static int FSBlockStore_PreflightGet(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
@@ -935,7 +935,7 @@ static int FSBlockStore_GetIndexSync(
 
 static int FSBlockStore_GetExistingContent(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes,
     uint32_t min_block_usage_percent,
     struct Longtail_AsyncGetExistingContentAPI* async_complete_api)
@@ -966,7 +966,7 @@ static int FSBlockStore_GetExistingContent(
     struct Longtail_StoreIndex* existing_store_index;
     err = Longtail_GetExistingStoreIndex(
         store_index,
-        (uint32_t)chunk_count,
+        chunk_count,
         chunk_hashes,
         min_block_usage_percent,
         fsblockstore_api->m_DefaultMaxBlockSize,

--- a/lib/lrublockstore/longtail_lrublockstore.c
+++ b/lib/lrublockstore/longtail_lrublockstore.c
@@ -298,12 +298,12 @@ static int LRUBlockStore_PutStoredBlock(
 
 static int LRUBlockStore_PreflightGet(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(block_store_api, "%p"),
-        LONGTAIL_LOGFIELD(chunk_count, "%" PRIx64),
+        LONGTAIL_LOGFIELD(chunk_count, "%u"),
         LONGTAIL_LOGFIELD(chunk_hashes, "%p")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_DEBUG)
 
@@ -508,7 +508,7 @@ static int LRUBlockStore_GetStoredBlock(
 
 static int LRUBlockStore_GetExistingContent(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes,
     uint32_t min_block_usage_percent,
     struct Longtail_AsyncGetExistingContentAPI* async_complete_api)

--- a/lib/memstorage/longtail_memstorage.c
+++ b/lib/memstorage/longtail_memstorage.c
@@ -18,18 +18,45 @@
     #define alloca _alloca
 #endif
 
-static const uint32_t Prime = 0x01000193;
-static const uint32_t Seed  = 0x811C9DC5;
+static inline uint32_t murmur_32_scramble(uint32_t k) {
+    k *= 0xcc9e2d51;
+    k = (k << 15) | (k >> 17);
+    k *= 0x1b873593;
+    return k;
+}
 
-static uint32_t fnv1a(const void* data, uint32_t numBytes)
+static uint32_t murmur3_32(const uint8_t* key, size_t len, uint32_t seed)
 {
-    uint32_t hash = Seed;
-    const unsigned char* ptr = (const unsigned char*)data;
-    while (numBytes--)
-    {
-        hash = ((*ptr++) ^ hash) * Prime;
+	uint32_t h = seed;
+    uint32_t k;
+    /* Read in groups of 4. */
+    for (size_t i = len >> 2; i; i--) {
+        // Here is a source of differing results across endiannesses.
+        // A swap here has no effects on hash properties though.
+        memcpy(&k, key, sizeof(uint32_t));
+        key += sizeof(uint32_t);
+        h ^= murmur_32_scramble(k);
+        h = (h << 13) | (h >> 19);
+        h = h * 5 + 0xe6546b64;
     }
-    return hash;
+    /* Read the rest. */
+    k = 0;
+    for (size_t i = len & 3; i; i--) {
+        k <<= 8;
+        k |= key[i - 1];
+    }
+    // A swap is *not* necessary here because the preceding loop already
+    // places the low bytes in the low places according to whatever endianness
+    // we use. Swaps only apply when the memory is copied in a chunk.
+    h ^= murmur_32_scramble(k);
+    /* Finalize. */
+	h ^= len;
+	h ^= h >> 16;
+	h *= 0x85ebca6b;
+	h ^= h >> 13;
+	h *= 0xc2b2ae35;
+	h ^= h >> 16;
+	return h;
 }
 
 struct PathEntry
@@ -88,13 +115,15 @@ static void InMemStorageAPI_ToLowerCase(char *str)
     }
 }
 
+static const uint32_t Seed  = 0x811C9DC5;
+
 static uint32_t InMemStorageAPI_GetPathHash(const char* path)
 {
     uint32_t pathlen = (uint32_t)strlen(path);
     char* buf = (char*)alloca(pathlen + 1);
     memcpy(buf, path, pathlen + 1);
     InMemStorageAPI_ToLowerCase(buf);
-    return fnv1a((void*)buf, pathlen);
+    return murmur3_32((void*)buf, pathlen, Seed);
 }
 
 static int InMemStorageAPI_OpenReadFile(struct Longtail_StorageAPI* storage_api, const char* path, Longtail_StorageAPI_HOpenFile* out_open_file)
@@ -128,7 +157,7 @@ static int InMemStorageAPI_OpenReadFile(struct Longtail_StorageAPI* storage_api,
         if (path_entry->m_IsOpenWrite)
         {
             Longtail_UnlockSpinLock(instance->m_SpinLock);
-            LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_INFO, "File already open for write, failed with %d", EPERM)
+            LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "File already open for write, failed with %d", EPERM)
             return EPERM;
         }
         ++path_entry->m_IsOpenRead;
@@ -508,6 +537,12 @@ static int InMemStorageAPI_CreateDir(struct Longtail_StorageAPI* storage_api, co
     if (source_path_ptr != -1)
     {
         struct PathEntry* path_entry = &instance->m_PathEntries[instance->m_PathHashToContent[source_path_ptr].value];
+        if (path_entry->m_IsOpenRead || path_entry->m_IsOpenWrite)
+        {
+            Longtail_UnlockSpinLock(instance->m_SpinLock);
+            LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Directory already open as a file, failed with %d", EIO)
+            return EIO;
+        }
         if ((path_entry->m_Permissions & (Longtail_StorageAPI_OtherWriteAccess | Longtail_StorageAPI_GroupWriteAccess | Longtail_StorageAPI_UserWriteAccess)) == 0)
         {
             Longtail_UnlockSpinLock(instance->m_SpinLock);
@@ -520,7 +555,7 @@ static int InMemStorageAPI_CreateDir(struct Longtail_StorageAPI* storage_api, co
             return EEXIST;
         }
         Longtail_UnlockSpinLock(instance->m_SpinLock);
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_INFO, "Directory already exists failed with %d", EIO)
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Directory already exists as a file, failed with %d", EIO)
         return EIO;
     }
 
@@ -531,6 +566,8 @@ static int InMemStorageAPI_CreateDir(struct Longtail_StorageAPI* storage_api, co
     path_entry->m_FileName = Longtail_Strdup(InMemStorageAPI_GetFileNamePart(path));
     path_entry->m_Content = 0;
     path_entry->m_Permissions = 0775;
+    path_entry->m_IsOpenRead = 0;
+    path_entry->m_IsOpenWrite = 0;
     hmput(instance->m_PathHashToContent, path_hash, (uint32_t)entry_index);
     Longtail_UnlockSpinLock(instance->m_SpinLock);
     return 0;

--- a/lib/memstorage/longtail_memstorage.c
+++ b/lib/memstorage/longtail_memstorage.c
@@ -123,7 +123,7 @@ static uint32_t InMemStorageAPI_GetPathHash(const char* path)
     char* buf = (char*)alloca(pathlen + 1);
     memcpy(buf, path, pathlen + 1);
     InMemStorageAPI_ToLowerCase(buf);
-    return murmur3_32((void*)buf, pathlen, Seed);
+    return murmur3_32((const uint8_t*)buf, pathlen, Seed);
 }
 
 static int InMemStorageAPI_OpenReadFile(struct Longtail_StorageAPI* storage_api, const char* path, Longtail_StorageAPI_HOpenFile* out_open_file)

--- a/lib/shareblockstore/longtail_shareblockstore.c
+++ b/lib/shareblockstore/longtail_shareblockstore.c
@@ -170,7 +170,7 @@ static int ShareBlockStore_PutStoredBlock(
 
 static int ShareBlockStore_PreflightGet(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
@@ -378,7 +378,7 @@ static int ShareBlockStore_GetStoredBlock(
 
 static int ShareBlockStore_GetExistingContent(
     struct Longtail_BlockStoreAPI* block_store_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes,
     uint32_t min_block_usage_percent,
     struct Longtail_AsyncGetExistingContentAPI* async_complete_api)

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -6129,8 +6129,6 @@ int Longtail_GetExistingStoreIndex(
     uint32_t chunk_count,
     const TLongtail_Hash* chunks,
     uint32_t min_block_usage_percent,
-    uint32_t max_block_size,
-    uint32_t max_chunks_per_block,
     struct Longtail_StoreIndex** out_store_index)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
@@ -6138,8 +6136,6 @@ int Longtail_GetExistingStoreIndex(
         LONGTAIL_LOGFIELD(chunk_count, "%u"),
         LONGTAIL_LOGFIELD(chunks, "%p"),
         LONGTAIL_LOGFIELD(min_block_usage_percent, "%u"),
-        LONGTAIL_LOGFIELD(max_block_size, "%u"),
-        LONGTAIL_LOGFIELD(max_chunks_per_block, "%u"),
         LONGTAIL_LOGFIELD(out_store_index, "%p")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_INFO)
 

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -2082,9 +2082,9 @@ static int ChunkAssets(
         {
             LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "AllocChunkAssetsData() failed with %d", ENOMEM)
             for (uint32_t i = 0; i < jobs_started; ++i)
-        {
+            {
                 Longtail_Free(tmp_hash_jobs[i].m_ChunkHashes);
-        }
+            }
             Longtail_Free(work_mem);
             return ENOMEM;
         }
@@ -5392,7 +5392,6 @@ static int WriteAssets(
         LONGTAIL_FATAL_ASSERT(ctx, err == 0, return err)
 
         job->m_VersionStorageAPI = version_storage_api;
-//        job->m_StoreIndex = store_index;
         job->m_VersionIndex = version_index;
         job->m_VersionFolder = version_path;
         job->m_BlockIndex = block_index;

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -5887,7 +5887,7 @@ int Longtail_CreateStoreIndex(
 
     int err = Longtail_CreateStoreIndexFromBlocks(
         block_count,
-        tmp_block_indexes,
+        (const struct Longtail_BlockIndex**)tmp_block_indexes,
         out_store_index);
     if (err)
     {
@@ -6329,7 +6329,10 @@ int Longtail_GetExistingStoreIndex(
     }
     Longtail_Free(tmp_mem);
 
-    int err = Longtail_CreateStoreIndexFromBlocks(found_block_count, block_index_header_ptrs, out_store_index);
+    int err = Longtail_CreateStoreIndexFromBlocks(
+        found_block_count,
+        (const struct Longtail_BlockIndex**)block_index_header_ptrs,
+        out_store_index);
     Longtail_Free(tmp_mem_2);
     if (err)
     {

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -5891,7 +5891,7 @@ int Longtail_CreateStoreIndex(
         out_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Longtail_CreateContentIndexFromBlocks() failed with %d", err)
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Longtail_CreateStoreIndexFromBlocks() failed with %d", err)
         return err;
     }
 
@@ -5963,7 +5963,7 @@ int Longtail_CreateMissingContent(
             out_store_index);
         if (err)
         {
-            LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Longtail_CreateContentIndex() failed with %d", err)
+            LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Longtail_CreateStoreIndexFromBlocks() failed with %d", err)
         }
         return err;
     }
@@ -7683,10 +7683,10 @@ const char* Longtail_FileInfos_GetPath(const struct Longtail_FileInfos* file_inf
 uint64_t Longtail_FileInfos_GetSize(const struct Longtail_FileInfos* file_infos, uint32_t index) { return file_infos->m_Sizes[index]; }
 const uint16_t* Longtail_FileInfos_GetPermissions(const struct Longtail_FileInfos* file_infos, uint32_t index) { return file_infos->m_Permissions; }
 
-uint32_t Longtail_VersionIndex_GetVersion(const struct Longtail_VersionIndex* content_index) { return *content_index->m_Version; }
-uint32_t Longtail_VersionIndex_GetHashAPI(const struct Longtail_VersionIndex* content_index) { return *content_index->m_HashIdentifier; }
-uint32_t Longtail_VersionIndex_GetAssetCount(const struct Longtail_VersionIndex* content_index) { return *content_index->m_AssetCount; }
-uint32_t Longtail_VersionIndex_GetChunkCount(const struct Longtail_VersionIndex* content_index) { return *content_index->m_ChunkCount; }
+uint32_t Longtail_VersionIndex_GetVersion(const struct Longtail_VersionIndex* version_index) { return *version_index->m_Version; }
+uint32_t Longtail_VersionIndex_GetHashAPI(const struct Longtail_VersionIndex* version_index) { return *version_index->m_HashIdentifier; }
+uint32_t Longtail_VersionIndex_GetAssetCount(const struct Longtail_VersionIndex* version_index) { return *version_index->m_AssetCount; }
+uint32_t Longtail_VersionIndex_GetChunkCount(const struct Longtail_VersionIndex* version_index) { return *version_index->m_ChunkCount; }
 
 uint32_t Longtail_StoreIndex_GetVersion(const struct Longtail_StoreIndex* store_index) { return *store_index->m_Version;}
 uint32_t Longtail_StoreIndex_GetHashIdentifier(const struct Longtail_StoreIndex* store_index) { return *store_index->m_HashIdentifier;}

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -6141,7 +6141,6 @@ int Longtail_GetExistingStoreIndex(
     size_t block_to_index_lookup_size = Longtail_LookupTable_GetSize(store_block_count);
     size_t chunk_to_store_index_lookup_size = Longtail_LookupTable_GetSize(chunk_count);
     size_t found_store_block_hashes_size = sizeof(TLongtail_Hash) * store_block_count;
-    size_t found_store_chunk_per_block_size = sizeof(uint32_t) * store_block_count;
     size_t block_uses_size = sizeof(uint32_t) * store_block_count;
     size_t block_sizes_size = sizeof(uint32_t) * store_block_count;
     size_t block_order_size = sizeof(uint32_t) * store_block_count;
@@ -6149,7 +6148,6 @@ int Longtail_GetExistingStoreIndex(
     size_t tmp_mem_size = chunk_to_index_lookup_size +
         block_to_index_lookup_size +
         chunk_to_store_index_lookup_size +
-        found_store_chunk_per_block_size +
         found_store_block_hashes_size +
         block_uses_size +
         block_sizes_size +
@@ -6174,9 +6172,6 @@ int Longtail_GetExistingStoreIndex(
 
     TLongtail_Hash* found_store_block_hashes = (TLongtail_Hash*)p;
     p += found_store_block_hashes_size;
-
-    uint32_t* found_store_chunk_per_block = (uint32_t*)p;
-    p += found_store_chunk_per_block_size;
 
     uint32_t* block_uses = (uint32_t*)p;
     p += block_uses_size;
@@ -6264,12 +6259,10 @@ int Longtail_GetExistingStoreIndex(
                     if (block_index_ptr == 0)
                     {
                         found_store_block_hashes[found_block_count++] = block_hash;
-                        found_store_chunk_per_block[current_found_block_index] = 1;
                     }
                     ++store_chunk_index_offset;
                     continue;
                 }
-                found_store_chunk_per_block[current_found_block_index]++;
                 ++store_chunk_index_offset;
             }
         }

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -7680,6 +7680,9 @@ uint32_t Longtail_VersionIndex_GetVersion(const struct Longtail_VersionIndex* ve
 uint32_t Longtail_VersionIndex_GetHashAPI(const struct Longtail_VersionIndex* version_index) { return *version_index->m_HashIdentifier; }
 uint32_t Longtail_VersionIndex_GetAssetCount(const struct Longtail_VersionIndex* version_index) { return *version_index->m_AssetCount; }
 uint32_t Longtail_VersionIndex_GetChunkCount(const struct Longtail_VersionIndex* version_index) { return *version_index->m_ChunkCount; }
+const TLongtail_Hash* Longtail_VersionIndex_GetChunkHashes(const struct Longtail_VersionIndex* version_index) { return version_index->m_ChunkHashes;}
+const uint32_t* Longtail_VersionIndex_GetChunkSizes(const struct Longtail_VersionIndex* version_index) { return version_index->m_ChunkSizes;}
+const uint32_t* Longtail_VersionIndex_GetChunkTags(const struct Longtail_VersionIndex* version_index) { return version_index->m_ChunkTags;}
 
 uint32_t Longtail_StoreIndex_GetVersion(const struct Longtail_StoreIndex* store_index) { return *store_index->m_Version;}
 uint32_t Longtail_StoreIndex_GetHashIdentifier(const struct Longtail_StoreIndex* store_index) { return *store_index->m_HashIdentifier;}

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -1458,8 +1458,6 @@ LONGTAIL_EXPORT int Longtail_GetExistingStoreIndex(
     uint32_t chunk_count,
     const TLongtail_Hash* chunks,
     uint32_t min_block_usage_percent,
-    uint32_t max_block_size,
-    uint32_t max_chunks_per_block,
     struct Longtail_StoreIndex** out_store_index);
 
 /*! @brief Validate that store_index contains all of version_index.

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -25,7 +25,6 @@ struct Longtail_Paths;
 struct Longtail_FileInfos;
 struct Longtail_VersionIndex;
 struct Longtail_StoredBlock;
-struct Longtail_ContentIndex;
 struct Longtail_VersionDiff;
 struct Longtail_StoreIndex;
 
@@ -595,7 +594,7 @@ LONGTAIL_EXPORT void Longtail_AsyncGetStoredBlock_OnComplete(struct Longtail_Asy
 
 struct Longtail_AsyncGetExistingContentAPI;
 
-typedef void (*Longtail_AsyncGetExistingContent_OnCompleteFunc)(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err);
+typedef void (*Longtail_AsyncGetExistingContent_OnCompleteFunc)(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_StoreIndex* store_index, int err);
 
 struct Longtail_AsyncGetExistingContentAPI
 {
@@ -610,7 +609,7 @@ LONGTAIL_EXPORT struct Longtail_AsyncGetExistingContentAPI* Longtail_MakeAsyncGe
     Longtail_DisposeFunc dispose_func,
     Longtail_AsyncGetExistingContent_OnCompleteFunc on_complete_func);
 
-LONGTAIL_EXPORT void Longtail_AsyncGetExistingContent_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_ContentIndex* content_index, int err);
+LONGTAIL_EXPORT void Longtail_AsyncGetExistingContent_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_StoreIndex* store_index, int err);
 
 ////////////// Longtail_AsyncFlushAPI
 
@@ -950,105 +949,6 @@ LONGTAIL_EXPORT int Longtail_ReadVersionIndex(
     const char* path,
     struct Longtail_VersionIndex** out_version_index);
 
-/*! @brief Get size of content index data.
- *
- * Content index data size is the size raw size of the content index excluding the struct Longtail_ContentIndex
- * header structure.
- *
- * @param[in] block_count           Number of blocks
- * @param[in] chunk_count           Number of chunks
- * @return                          Number of bytes required to store the content index data
- */
-LONGTAIL_EXPORT size_t Longtail_GetContentIndexDataSize(
-    uint64_t block_count,
-    uint64_t chunk_count);
-
-/*! @brief Get size of content index.
- *
- * Content index data size is the size size of the content index including the struct Longtail_ContentIndex
- * header structure.
- *
- * @param[in] block_count           Number of blocks
- * @param[in] chunk_count           Number of chunks
- * @return                          Number of bytes required to store the content index data
- */
-LONGTAIL_EXPORT size_t Longtail_GetContentIndexSize(
-    uint64_t block_count,
-    uint64_t chunk_count);
-
-/*! @brief Initialize content index from raw data.
- *
- * Initialize a struct Longtail_ContentIndex from raw data.
- *
- * @param[in] content_index Pointer to an uninitialized struct Longtail_VersionIndex
- * @param[in] data          Pointer to a raw content index data
- * @param[in] data_size     Size of raw content index data
- * @return                  Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_InitContentIndexFromData(
-    struct Longtail_ContentIndex* content_index,
-    void* data,
-    uint64_t data_size);
-
-/*! @brief Initialize content index.
- *
- * Initialize a chunk of memory to a struct Longtail_ContentIndex.
- *
- * @param[in] mem                   Pointer to memory to initialize, must be of at least Longtail_GetContentIndexSize(@p block_count, @ chunk_count) size
- * @param[in] hash_api              Hash API identifier
- * @param[in] max_block_size        Max block size
- * @param[in] max_chunks_per_block  Max chunks per block
- * @param[in] block_count           Block count
- * @param[in] chunk_count           Chunk count
- * @return                          An initialized struct Longtail_ContentIndex*, zero of failure
- */
-LONGTAIL_EXPORT struct Longtail_ContentIndex* Longtail_InitContentIndex(
-    void* mem,
-    uint32_t hash_api,
-    uint32_t max_block_size,
-    uint32_t max_chunks_per_block,
-    uint64_t block_count,
-    uint64_t chunk_count);
-
-/*! @brief Create a struct Longtail_ContentIndex from array of struct Longtail_BlockIndex.
- *
- * Allocates and initializes a struct Longtail_ContentIndex structure from an array of
- * struct Longtail_BlockIndex using Longtail_Alloc()
- * The resulting struct Longtail_ContentIndex is freed with Longtail_Free()
- *
- * @param[in] max_block_size        Max block size
- * @param[in] max_chunks_per_block  Max chunks per block
- * @param[in] block_count           Block count - number of struct Longtail_BlockIndex pointers in @p block_indexes
- * @param[in] block_indexes         Array of pointers to initialized struct Longtail_BlockIndex
- * @param[out] out_content_index    Pointer to an struct Longtail_ContentIndex pointer
- * @return                          Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_CreateContentIndexFromBlocks(
-    uint32_t max_block_size,
-    uint32_t max_chunks_per_block,
-    uint64_t block_count,
-    struct Longtail_BlockIndex** block_indexes,
-    struct Longtail_ContentIndex** out_content_index);
-
-/*! @brief Create a struct Longtail_ContentIndex from an struct Longtail_VersionIndex.
- *
- * Creates a struct Longtail_ContentIndex from a struct Longtail_VersionIndex by bundling
- * chunks into blocks according to @p max_block_size and @p max_chunks_per_block.
- *
- * @param[in] hash_api              Hash API identifier
- * @param[in] version_index         Pointer to an initialized struct Longtail_VersionIndex
- * @param[in] max_block_size        Max block size
- * @param[in] max_chunks_per_block  Max chunks per block
- * @param[out] out_content_index    Pointer to an struct Longtail_ContentIndex pointer
- * @return                          Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_CreateContentIndex(
-    struct Longtail_HashAPI* hash_api,
-    struct Longtail_VersionIndex* version_index,
-    uint32_t max_block_size,
-    uint32_t max_chunks_per_block,
-    struct Longtail_ContentIndex** out_content_index);
-
 /*! @brief Get the chunks required to go to @p version_index by applying @p version_diff.
  *
  * Gets all the chunks required to apply @p version_diff which is a subset of all chunks in @p version_index
@@ -1064,71 +964,6 @@ LONGTAIL_EXPORT int Longtail_GetRequiredChunkHashes(
     const struct Longtail_VersionDiff* version_diff,
     uint64_t* out_chunk_count,
     TLongtail_Hash* out_chunk_hashes);
-
-/*! @brief Create a struct Longtail_ContentIndex from discreet data.
- *
- * Creates a struct Longtail_ContentIndex from discreet data by bundling
- * chunks into blocks according to @p max_block_size and @p max_chunks_per_block.
- *
- * @param[in] hash_api              Hash API identifier
- * @param[in] chunk_count           Number of chunks
- * @param[in] chunk_hashes          Array of chunk hashes - entry count must match @p chunk_count
- * @param[in] chunk_sizes           Array of chunk sizes - entry count must match @p chunk_count
- * @param[in] optional_chunk_tags   Array of chunk tags - entry count must match @p chunk_count or be set to 0 for no tagging
- * @param[in] max_block_size        Max block size
- * @param[in] max_chunks_per_block  Max chunks per block
- * @param[out] out_content_index    Pointer to an struct Longtail_ContentIndex pointer
- * @return                          Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_CreateContentIndexRaw(
-    struct Longtail_HashAPI* hash_api,
-    uint64_t chunk_count,
-    const TLongtail_Hash* chunk_hashes,
-    const uint32_t* chunk_sizes,
-    const uint32_t* optional_chunk_tags,
-    uint32_t max_block_size,
-    uint32_t max_chunks_per_block,
-    struct Longtail_ContentIndex** out_content_index);
-
-LONGTAIL_EXPORT int Longtail_CreateContentIndexFromStoreIndex(
-    const struct Longtail_StoreIndex* store_index,
-    uint32_t max_block_size,
-    uint32_t max_chunks_per_block,
-    struct Longtail_ContentIndex** out_content_index);
-
-/*! @brief Writes a struct Longtail_ContentIndex to a byte buffer.
- *
- * Serializes a struct Longtail_ContentIndex to a buffer which is allocated using Longtail_Alloc()
- * 
- * NOTE: This should only be used to transport a content index - never to storage
- * TODO: Replace this with Longtail_PackContentIndex() ?
- *
- * @param[in] content_index         Pointer to an initialized struct Longtail_ContentIndex
- * @param[out] out_buffer           Pointer to a buffer pointer intitialized on success
- * @param[out] out_size             Pointer to a size variable intitialized on success
- * @return                          Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_WriteContentIndexToBuffer(
-    const struct Longtail_ContentIndex* content_index,
-    void** out_buffer,
-    size_t* out_size);
-
-/*! @brief Reads a struct Longtail_ContentIndex from a byte buffer.
- *
- * Deserializes a struct Longtail_ContentIndex from a buffer, the struct Longtail_ContentIndex is allocated using Longtail_Alloc()
- * 
- * NOTE: This should only be used to transport a content index - never to storage
- * TODO: Replace this with Longtail_UnpackContentIndex() ?
- *
- * @param[in] buffer                Buffer containing the serialized struct Longtail_ContentIndex
- * @param[in] size                  Size of the buffer
- * @param[out] out_content_index    Pointer to an struct Longtail_ContentIndex pointer
- * @return                          Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_ReadContentIndexFromBuffer(
-    const void* buffer,
-    size_t size,
-    struct Longtail_ContentIndex** out_content_index);
 
 /*! @brief Write content blocks from version data
  *
@@ -1153,7 +988,7 @@ LONGTAIL_EXPORT int Longtail_WriteContent(
     struct Longtail_ProgressAPI* progress_api,
     struct Longtail_CancelAPI* optional_cancel_api,
     Longtail_CancelAPI_HCancelToken optional_cancel_token,
-    struct Longtail_ContentIndex* content_index,
+    struct Longtail_StoreIndex* store_index,
     struct Longtail_VersionIndex* version_index,
     const char* assets_folder);
 
@@ -1163,20 +998,20 @@ LONGTAIL_EXPORT int Longtail_WriteContent(
  * Chunks that are not present in @p content_index will be bundled up in blocks according to @p max_block_size and @p max_chunks_per_block.
  *
  * @param[in] hash_api              An implementation of struct Longtail_HashAPI interface. This must match the hashing api used to create both content index index and version index
- * @param[in] content_index         The known content to check against
+ * @param[in] store_index           The known content to check against
  * @param[in] version_index         The version index content you test against @p reference_content_index
  * @param[in] max_block_size        The maximum size if bytes one block is allowed to be
  * @param[in] max_chunks_per_block  The maximum number of chunks allowed inside one block
- * @param[out] out_content_index    The resulting missing content index will be created and assigned to this pointer reference if successful
+ * @param[out] out_store_index      The resulting missing store index will be created and assigned to this pointer reference if successful
  * @return                          Return code (errno style), zero on success
  */
 LONGTAIL_EXPORT int Longtail_CreateMissingContent(
     struct Longtail_HashAPI* hash_api,
-    const struct Longtail_ContentIndex* content_index,
+    const struct Longtail_StoreIndex* store_index,
     const struct Longtail_VersionIndex* version_index,
     uint32_t max_block_size,
     uint32_t max_chunks_per_block,
-    struct Longtail_ContentIndex** out_content_index);
+    struct Longtail_StoreIndex** out_store_index);
 
 
 /*! @brief Generate a content index with what is missing.
@@ -1187,68 +1022,19 @@ LONGTAIL_EXPORT int Longtail_CreateMissingContent(
  *
  * The missing blocks are added in complete form so you might get redundant content in @p out_content_index.
  *
- * @param[in] hash_identifier           The hash identifier to use, if any of the content_indexes has any blocks their hash identifier must match @p hash_identifier
- * @param[in] reference_content_index   The known content to check against
- * @param[in] content_index             The content you want to test against @p reference_content_index
- * @param[out] out_content_index        The resulting missing content index will be created and assigned to this pointer reference if successful
+ * @param[in] store_index               ???
+ * @param[in] chunk_count               ???
+ * @param[in] chunk_hashes              ???
+ * @param[out] out_chunk_count          ???
+ * @param[out] out_missing_chunk_hashes ???
  * @return                              Return code (errno style), zero on success
  */
 LONGTAIL_EXPORT int Longtail_GetMissingChunks(
-    const struct Longtail_ContentIndex* content_index,
+    const struct Longtail_StoreIndex* store_index,
     uint64_t chunk_count,
     const TLongtail_Hash* chunk_hashes,
     uint64_t* out_chunk_count,
     TLongtail_Hash* out_missing_chunk_hashes);
-
-/*! @brief Retarget a content index to match an existing content index.
- *
- * Create a new struct Longtail_ContentIndex keeping only the blocks in @p reference_content_index
- * that contains chunks found in @content_index.
- *
- * The result is the chunks known in @p reference_content_index arrangend in blocks known to @p reference_content_index.
- * Use Longtail_CreateMissingContent() to create blocks of any chunks not found in @p reference_content_index
- *
- * @param[in] reference_content_index   The known content to check against
- * @param[in] requested_content_index   The content you want to test against @p reference_content_index
- * @param[out] out_content_index        The blocks/chunks of requested_content_index found in reference_content_index
- * @return                              Return code (errno style), zero on success
- */
-/*LONGTAIL_EXPORT int Longtail_RetargetContent(
-    const struct Longtail_ContentIndex* reference_content_index,
-    const struct Longtail_ContentIndex* requested_content_index,
-    struct Longtail_ContentIndex** out_content_index);
-*/
-/*! @brief Merge two content indexes.
- *
- * Create a join of two content indexes, @p local_content_index has precedence, if a chunk is present in @p local_content_index the
- * block containing it is added to @p out_content_index over a block from @p new_content_index.
- *
- * @param[in] job_api                   An initialized struct Longtail_JobAPI
- * @param[in] local_content_index       The known content used a base
- * @param[in] new_content_index         The content you want add - only blocks containing chunks not in @p local_content_index will be added
- * @param[out] out_content_index        The resulting content index will be created and assigned to this pointer reference if successful
- * @return                              Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_MergeContentIndex(
-    struct Longtail_JobAPI* job_api,
-    struct Longtail_ContentIndex* local_content_index,
-    struct Longtail_ContentIndex* new_content_index,
-    struct Longtail_ContentIndex** out_content_index);
-
-/*! @brief Add two content indexes.
- *
- * Create a join of two content indexes, @p local_content_index is added first and @p new_content_index is added to that
- * without any checking of duplicate chunks or blocks.
- *
- * @param[in] local_content_index       The known content used a base
- * @param[in] new_content_index         The content you want add - add chunks and blocks from @p new_content_index will be added
- * @param[out] out_content_index        The resulting content index will be created and assigned to this pointer reference if successful
- * @return                              Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_AddContentIndex(
-    struct Longtail_ContentIndex* local_content_index,
-    struct Longtail_ContentIndex* new_content_index,
-    struct Longtail_ContentIndex** out_content_index);
 
 /*! @brief Unpack and write a version.
  *
@@ -1277,7 +1063,7 @@ LONGTAIL_EXPORT int Longtail_WriteVersion(
     struct Longtail_ProgressAPI* progress_api,
     struct Longtail_CancelAPI* optional_cancel_api,
     Longtail_CancelAPI_HCancelToken optional_cancel_token,
-    const struct Longtail_ContentIndex* content_index,
+    const struct Longtail_StoreIndex* store_index,
     const struct Longtail_VersionIndex* version_index,
     const char* version_path,
     int retain_permissions);
@@ -1329,7 +1115,7 @@ LONGTAIL_EXPORT int Longtail_ChangeVersion(
     struct Longtail_ProgressAPI* progress_api,
     struct Longtail_CancelAPI* optional_cancel_api,
     Longtail_CancelAPI_HCancelToken optional_cancel_token,
-    const struct Longtail_ContentIndex* content_index,
+    const struct Longtail_StoreIndex* store_index,
     const struct Longtail_VersionIndex* source_version,
     const struct Longtail_VersionIndex* target_version,
     const struct Longtail_VersionDiff* version_diff,
@@ -1575,28 +1361,15 @@ LONGTAIL_EXPORT int Longtail_ReadStoredBlock(
 
 /*! @brief Validate that content_index contains all of version_index.
  *
- * Validates that all chunks required for @p version_index are present in @p content_index
+ * Validates that all chunks required for @p version_index are present in @p store_index
  * Validates that reconstructing an asset via chunks results in the same size as recorded in @p version_index
  *
- * @param[in] content_index         The content index to validate
- * @param[in] version_index         The version index used to validate the content of @p content_index
+ * @param[in] store_index           The store index to validate
+ * @param[in] version_index         The version index used to validate the content of @p store_index
  * @return                          Return code (errno style), zero on success. Success is when all content required is present
  */
-LONGTAIL_EXPORT int Longtail_ValidateContent(
-    const struct Longtail_ContentIndex* content_index,
-    const struct Longtail_VersionIndex* version_index);
-
-/*! @brief Validate that version_index contains all of content_index.
- *
- * Validates that all chunks present in @p content_index are present in @p version_index
- * Validates that reconstructing an asset via chunks results in the same size as recorded in @p version_index
- *
- * @param[in] content_index         The content index to validate
- * @param[in] version_index         The version index used to validate the content of @p content_index
- * @return                          Return code (errno style), zero on success. Success is when all content required is present
- */
-LONGTAIL_EXPORT int Longtail_ValidateVersion(
-    const struct Longtail_ContentIndex* content_index,
+LONGTAIL_EXPORT int Longtail_ValidateStore(
+    const struct Longtail_StoreIndex* store_index,
     const struct Longtail_VersionIndex* version_index);
 
 struct Longtail_BlockIndex
@@ -1645,28 +1418,6 @@ LONGTAIL_EXPORT const struct Longtail_Paths* Longtail_FileInfos_GetPaths(const s
 LONGTAIL_EXPORT uint64_t Longtail_FileInfos_GetSize(const struct Longtail_FileInfos* file_infos, uint32_t index);
 LONGTAIL_EXPORT const uint16_t* Longtail_FileInfos_GetPermissions(const struct Longtail_FileInfos* file_infos, uint32_t index);
 
-extern uint32_t Longtail_CurrentContentIndexVersion;
-
-struct Longtail_ContentIndex
-{
-    uint32_t* m_Version;
-    uint32_t* m_HashIdentifier;
-    uint32_t* m_MaxBlockSize;
-    uint32_t* m_MaxChunksPerBlock;
-    uint64_t* m_BlockCount;
-    uint64_t* m_ChunkCount;
-
-    TLongtail_Hash* m_BlockHashes;      // []
-    TLongtail_Hash* m_ChunkHashes;      // []
-    uint64_t* m_ChunkBlockIndexes;      // []
-};
-
-LONGTAIL_EXPORT uint32_t Longtail_ContentIndex_GetVersion(const struct Longtail_ContentIndex* content_index);
-LONGTAIL_EXPORT uint32_t Longtail_ContentIndex_GetHashAPI(const struct Longtail_ContentIndex* content_index);
-LONGTAIL_EXPORT uint64_t Longtail_ContentIndex_GetBlockCount(const struct Longtail_ContentIndex* content_index);
-LONGTAIL_EXPORT uint64_t Longtail_ContentIndex_GetChunkCount(const struct Longtail_ContentIndex* content_index);
-LONGTAIL_EXPORT const TLongtail_Hash* Longtail_ContentIndex_BlockHashes(const struct Longtail_ContentIndex* content_index);
-
 struct Longtail_StoreIndex
 {
     uint32_t* m_Version;
@@ -1699,11 +1450,6 @@ LONGTAIL_EXPORT int Longtail_CreateStoreIndexFromBlocks(
     const struct Longtail_BlockIndex** block_indexes,
     struct Longtail_StoreIndex** out_store_index);
 
-LONGTAIL_EXPORT int Longtail_CreateStoreIndexFromContentIndex(
-    const struct Longtail_ContentIndex* content_index,
-    uint32_t blocks_tag,
-    struct Longtail_StoreIndex** out_store_index);
-
 LONGTAIL_EXPORT int Longtail_MergeStoreIndex(
     const struct Longtail_StoreIndex* local_store_index,
     const struct Longtail_StoreIndex* remote_store_index,
@@ -1714,14 +1460,14 @@ LONGTAIL_EXPORT int Longtail_MakeBlockIndex(
     uint32_t block_index,
     struct Longtail_BlockIndex* out_block_index);
 
-LONGTAIL_EXPORT int Longtail_GetExistingContentIndex(
+LONGTAIL_EXPORT int Longtail_GetExistingStoreIndex(
     const struct Longtail_StoreIndex* store_index,
     uint32_t chunk_count,
     const TLongtail_Hash* chunks,
     uint32_t min_block_usage_percent,
     uint32_t max_block_size,
     uint32_t max_chunks_per_block,
-    struct Longtail_ContentIndex** out_content_index);
+    struct Longtail_StoreIndex** out_store_index);
 
 /*! @brief Copies a struct Longtail_StoreIndex.
  *

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -967,7 +967,7 @@ LONGTAIL_EXPORT int Longtail_GetRequiredChunkHashes(
 
 /*! @brief Write content blocks from version data
  *
- * Writes all blocks for @p version_content_index using @p version_index and asset_path as data source to a block store
+ * Writes all blocks for @p store_index using @p version_index and asset_path as data source to a block store
  *
  * @param[in] source_storage_api        An initialized struct Longtail_StorageAPI
  * @param[in] block_store_api           An initialized struct Longtail_BlockStoreAPI
@@ -976,7 +976,7 @@ LONGTAIL_EXPORT int Longtail_GetRequiredChunkHashes(
  * @param[in] progress_api              An initialized struct Longtail_ProgressAPI, or 0 for no progress reporting
  * @param[in] optional_cancel_api       An implementation of struct Longtail_CancelAPI interface or null if no cancelling is required
  * @param[in] optional_cancel_token     A cancel token or null if @p optional_cancel_api is null
- * @param[in] content_index             The content index to write, all blocks in content index will be written
+ * @param[in] store_index               The store index to write, all blocks in store index will be written
  * @param[in] version_index             Version index of data in  @p assets_folder
  * @param[in] assets_folder             Path of version data inside @p source_storage_api
  * @return                  Return code (errno style), zero on success
@@ -992,14 +992,14 @@ LONGTAIL_EXPORT int Longtail_WriteContent(
     struct Longtail_VersionIndex* version_index,
     const char* assets_folder);
 
-/*! @brief Generate a content index with what is missing.
+/*! @brief Generate a store index with what is missing.
  *
- * Any content in @p version_index that is not present in @p content_index will be included in @p out_content_index
- * Chunks that are not present in @p content_index will be bundled up in blocks according to @p max_block_size and @p max_chunks_per_block.
+ * Any content in @p version_index that is not present in @p store_index will be included in @p out_store_index
+ * Chunks that are not present in @p store_index will be bundled up in blocks according to @p max_block_size and @p max_chunks_per_block.
  *
- * @param[in] hash_api              An implementation of struct Longtail_HashAPI interface. This must match the hashing api used to create both content index index and version index
- * @param[in] store_index           The known content to check against
- * @param[in] version_index         The version index content you test against @p reference_content_index
+ * @param[in] hash_api              An implementation of struct Longtail_HashAPI interface. This must match the hashing api used to create both store index index and version index
+ * @param[in] store_index           The known store index to check against
+ * @param[in] version_index         The version index content you test against @p store_index
  * @param[in] max_block_size        The maximum size if bytes one block is allowed to be
  * @param[in] max_chunks_per_block  The maximum number of chunks allowed inside one block
  * @param[out] out_store_index      The resulting missing store index will be created and assigned to this pointer reference if successful
@@ -1014,13 +1014,9 @@ LONGTAIL_EXPORT int Longtail_CreateMissingContent(
     struct Longtail_StoreIndex** out_store_index);
 
 
-/*! @brief Generate a content index with what is missing.
+/*! @brief Generates an array of all chunks missing in a store index.
  *
- * Any content in @p content_index that is not present in @p reference_content_index will be included in @p out_content_index
- * The content verification will only add blocks from @p content_index that has chunks it can not
- * find in @p reference_content_index.
- *
- * The missing blocks are added in complete form so you might get redundant content in @p out_content_index.
+ * Any chunk hashes in @p chunk_hashes that is not present in @p store_index will be included in @p out_missing_chunk_hashes
  *
  * @param[in] store_index               ???
  * @param[in] chunk_count               ???
@@ -1040,8 +1036,8 @@ LONGTAIL_EXPORT int Longtail_GetMissingChunks(
  *
  * Writes out a full version to @p version_storage_api at path @p version_path.
  * Usually done to an empty folder since it will not remove any assets that are not in @p version_index.
- * Uses @p content_index to know where chunks are located in blocks - this can either be the full
- * content index of @p block_storage_api or a content index that is slimmed down using Longtail_BlockStore_GetExistingContent.
+ * Uses @p store_index to know where chunks are located in blocks - this can either be the full
+ * store index of @p block_storage_api or a store index that is slimmed down using Longtail_BlockStore_GetExistingContent.
  * Blocks are fetched from @p block_storage_api on demand.
  *
  * @param[in] block_storage_api     An implementation of struct Longtail_BlockStoreAPI interface
@@ -1050,7 +1046,7 @@ LONGTAIL_EXPORT int Longtail_GetMissingChunks(
  * @param[in] progress_api          An initialized struct Longtail_ProgressAPI, or 0 for no progress reporting
  * @param[in] optional_cancel_api   An implementation of struct Longtail_CancelAPI interface or null if no cancelling is required
  * @param[in] optional_cancel_token A cancel token or null if @p optional_cancel_api is null
- * @param[in] content_index         The content index for @p block_store_api
+ * @param[in] store_index           The store index for @p block_store_api
  * @param[in] version_index         The version index for the version to write
  * @param[in] version_path          The path in @p version_storage_api to write the version to
  * @param[in] retain_permissions    Flag for setting permissions - 0 = don't set permissions, 1 = set permissions
@@ -1088,8 +1084,8 @@ LONGTAIL_EXPORT int Longtail_CreateVersionDiff(
 /*! @brief Unpack and modify a version.
  *
  * Applies the changes from @p version_diff to change a version from @p source_version to @p target_version.
- * Uses @p content_index to know where chunks are located in blocks - this can either be the full
- * content index of @p block_storage_api or a content index that is slimmed down using Longtail_BlockStore_GetExistingContent.
+ * Uses @p store_index to know where chunks are located in blocks - this can either be the full
+ * store index of @p block_storage_api or a store index that is slimmed down using Longtail_BlockStore_GetExistingContent.
  * Blocks are fetched from @p block_storage_api on demand.
  *
  * @param[in] block_storage_api     An implementation of struct Longtail_BlockStoreAPI interface
@@ -1099,7 +1095,7 @@ LONGTAIL_EXPORT int Longtail_CreateVersionDiff(
  * @param[in] progress_api          An initialized struct Longtail_ProgressAPI, or 0 for no progress reporting
  * @param[in] optional_cancel_api   An implementation of struct Longtail_CancelAPI interface or null if no cancelling is required
  * @param[in] optional_cancel_token A cancel token or null if @p optional_cancel_api is null
- * @param[in] content_index         @p target_version retargetted to @p block_storage_api (see Longtail_BlockStoreAPI::GetExistingContent)
+ * @param[in] store_index           @p target_version retargetted to @p block_storage_api (see Longtail_BlockStoreAPI::GetExistingContent)
  * @param[in] source_version        The version index for the current version
  * @param[in] target_version        The version index for the target version
  * @param[in] version_diff          The version diff between @p source_version and @p target_version
@@ -1183,7 +1179,7 @@ LONGTAIL_EXPORT int Longtail_InitBlockIndexFromData(
  * @param[in] chunk_indexes     Indexing into @p chunk_hashes
  * @param[in] chunk_hashes      Array of chunk hashes - it can contain many more hashes than chunks in block - use @p chunk_indexes array to identify hashes
  * @param[in] chunk_sizes       Array of chunk sizes - it can contain many more sizes than chunks in block - use @p chunk_indexes array to identify sizes
- * @param[out] out_block_index  The resulting content index will be created and assigned to this pointer reference if successful
+ * @param[out] out_block_index  The resulting block index will be created and assigned to this pointer reference if successful
  * @return                      Return code (errno style), zero on success
  */
 LONGTAIL_EXPORT int Longtail_CreateBlockIndex(
@@ -1466,7 +1462,7 @@ LONGTAIL_EXPORT int Longtail_GetExistingStoreIndex(
     uint32_t max_chunks_per_block,
     struct Longtail_StoreIndex** out_store_index);
 
-/*! @brief Validate that content_index contains all of version_index.
+/*! @brief Validate that store_index contains all of version_index.
  *
  * Validates that all chunks required for @p version_index are present in @p store_index
  * Validates that reconstructing an asset via chunks results in the same size as recorded in @p version_index
@@ -1573,10 +1569,10 @@ struct Longtail_VersionIndex
     char* m_NameData;
 };
 
-LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetVersion(const struct Longtail_VersionIndex* content_index);
-LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetHashAPI(const struct Longtail_VersionIndex* content_index);
-LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetAssetCount(const struct Longtail_VersionIndex* content_index);
-LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetChunkCount(const struct Longtail_VersionIndex* content_index);
+LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetVersion(const struct Longtail_VersionIndex* version_index);
+LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetHashAPI(const struct Longtail_VersionIndex* version_index);
+LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetAssetCount(const struct Longtail_VersionIndex* version_index);
+LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetChunkCount(const struct Longtail_VersionIndex* version_index);
 
 struct Longtail_VersionDiff
 {

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -1099,6 +1099,9 @@ LONGTAIL_EXPORT int Longtail_CreateContentIndexFromStoreIndex(
 /*! @brief Writes a struct Longtail_ContentIndex to a byte buffer.
  *
  * Serializes a struct Longtail_ContentIndex to a buffer which is allocated using Longtail_Alloc()
+ * 
+ * NOTE: This should only be used to transport a content index - never to storage
+ * TODO: Replace this with Longtail_PackContentIndex() ?
  *
  * @param[in] content_index         Pointer to an initialized struct Longtail_ContentIndex
  * @param[out] out_buffer           Pointer to a buffer pointer intitialized on success
@@ -1113,6 +1116,9 @@ LONGTAIL_EXPORT int Longtail_WriteContentIndexToBuffer(
 /*! @brief Reads a struct Longtail_ContentIndex from a byte buffer.
  *
  * Deserializes a struct Longtail_ContentIndex from a buffer, the struct Longtail_ContentIndex is allocated using Longtail_Alloc()
+ * 
+ * NOTE: This should only be used to transport a content index - never to storage
+ * TODO: Replace this with Longtail_UnpackContentIndex() ?
  *
  * @param[in] buffer                Buffer containing the serialized struct Longtail_ContentIndex
  * @param[in] size                  Size of the buffer
@@ -1122,36 +1128,6 @@ LONGTAIL_EXPORT int Longtail_WriteContentIndexToBuffer(
 LONGTAIL_EXPORT int Longtail_ReadContentIndexFromBuffer(
     const void* buffer,
     size_t size,
-    struct Longtail_ContentIndex** out_content_index);
-
-/*! @brief Writes a struct Longtail_ContentIndex.
- *
- * Serializes a struct Longtail_ContentIndex to a file in a struct Longtail_StorageAPI at the specified path.
- * The parent folder of the file path must exist.
- *
- * @param[in] storage_api   An initialized struct Longtail_StorageAPI
- * @param[in] content_index Pointer to an initialized struct Longtail_ContentIndex
- * @param[in] path          A path in the storage api to store the content index to
- * @return                  Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_WriteContentIndex(
-    struct Longtail_StorageAPI* storage_api,
-    struct Longtail_ContentIndex* content_index,
-    const char* path);
-
-/*! @brief Reads a struct Longtail_ContentIndex.
- *
- * Deserializes a struct Longtail_ContentIndex from a file in a struct Longtail_StorageAPI at the specified path.
- * The file must exist.
- *
- * @param[in] storage_api           An initialized struct Longtail_StorageAPI
- * @param[in] path                  A path in the storage api to read the Content index from
- * @param[out] out_content_index    Pointer to an struct Longtail_ContentIndex pointer
- * @return                          Return code (errno style), zero on success
- */
-LONGTAIL_EXPORT int Longtail_ReadContentIndex(
-    struct Longtail_StorageAPI* storage_api,
-    const char* path,
     struct Longtail_ContentIndex** out_content_index);
 
 /*! @brief Write content blocks from version data

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -1573,6 +1573,9 @@ LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetVersion(const struct Longtail_
 LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetHashAPI(const struct Longtail_VersionIndex* version_index);
 LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetAssetCount(const struct Longtail_VersionIndex* version_index);
 LONGTAIL_EXPORT uint32_t Longtail_VersionIndex_GetChunkCount(const struct Longtail_VersionIndex* version_index);
+LONGTAIL_EXPORT const TLongtail_Hash* Longtail_VersionIndex_GetChunkHashes(const struct Longtail_VersionIndex* version_index);
+LONGTAIL_EXPORT const uint32_t* Longtail_VersionIndex_GetChunkSizes(const struct Longtail_VersionIndex* version_index);
+LONGTAIL_EXPORT const uint32_t* Longtail_VersionIndex_GetChunkTags(const struct Longtail_VersionIndex* version_index);
 
 struct Longtail_VersionDiff
 {

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -671,9 +671,9 @@ struct Longtail_BlockStore_Stats
 };
 
 typedef int (*Longtail_BlockStore_PutStoredBlockFunc)(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_StoredBlock* stored_block, struct Longtail_AsyncPutStoredBlockAPI* async_complete_api);
-typedef int (*Longtail_BlockStore_PreflightGetFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes);
+typedef int (*Longtail_BlockStore_PreflightGetFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes);
 typedef int (*Longtail_BlockStore_GetStoredBlockFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_hash, struct Longtail_AsyncGetStoredBlockAPI* async_complete_api);
-typedef int (*Longtail_BlockStore_GetExistingContentFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent,  struct Longtail_AsyncGetExistingContentAPI* async_complete_api);
+typedef int (*Longtail_BlockStore_GetExistingContentFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent,  struct Longtail_AsyncGetExistingContentAPI* async_complete_api);
 typedef int (*Longtail_BlockStore_GetStatsFunc)(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats);
 typedef int (*Longtail_BlockStore_FlushFunc)(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_AsyncFlushAPI* async_complete_api);
 
@@ -702,9 +702,9 @@ LONGTAIL_EXPORT struct Longtail_BlockStoreAPI* Longtail_MakeBlockStoreAPI(
     Longtail_BlockStore_FlushFunc flush_func);
 
 LONGTAIL_EXPORT int Longtail_BlockStore_PutStoredBlock(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_StoredBlock* stored_block, struct Longtail_AsyncPutStoredBlockAPI* async_complete_api);
-LONGTAIL_EXPORT int Longtail_BlockStore_PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes);
+LONGTAIL_EXPORT int Longtail_BlockStore_PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes);
 LONGTAIL_EXPORT int Longtail_BlockStore_GetStoredBlock(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_hash, struct Longtail_AsyncGetStoredBlockAPI* async_complete_api);
-LONGTAIL_EXPORT int Longtail_BlockStore_GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api);
+LONGTAIL_EXPORT int Longtail_BlockStore_GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api);
 LONGTAIL_EXPORT int Longtail_BlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats);
 LONGTAIL_EXPORT int Longtail_BlockStore_Flush(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_AsyncFlushAPI* async_complete_api);
 
@@ -955,14 +955,14 @@ LONGTAIL_EXPORT int Longtail_ReadVersionIndex(
  *
  * @param[in] version_index         Pointer to an initialized struct Longtail_VersionIndex - the version we will have after applying @p version_diff
  * @param[in] version_diff          Pointer to an initialized struct Longtail_VersionDiff - the version diff to be applied to get to @p version_index
- * @param[out] out_chunk_count      Pointer to a uint64_t which will be set to the number of chunks required
+ * @param[out] out_chunk_count      Pointer to a uint32_t which will be set to the number of chunks required
  * @param[out] out_chunk_hashes     Pointer to a pre-allocated array where chunk indexes with be written - will add at most *version_index->m_ChunkCount chunks to array
  * @return                          Return code (errno style), zero on success
  */
 LONGTAIL_EXPORT int Longtail_GetRequiredChunkHashes(
     const struct Longtail_VersionIndex* version_index,
     const struct Longtail_VersionDiff* version_diff,
-    uint64_t* out_chunk_count,
+    uint32_t* out_chunk_count,
     TLongtail_Hash* out_chunk_hashes);
 
 /*! @brief Write content blocks from version data
@@ -1027,9 +1027,9 @@ LONGTAIL_EXPORT int Longtail_CreateMissingContent(
  */
 LONGTAIL_EXPORT int Longtail_GetMissingChunks(
     const struct Longtail_StoreIndex* store_index,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes,
-    uint64_t* out_chunk_count,
+    uint32_t* out_chunk_count,
     TLongtail_Hash* out_missing_chunk_hashes);
 
 /*! @brief Unpack and write a version.
@@ -1186,7 +1186,7 @@ LONGTAIL_EXPORT int Longtail_CreateBlockIndex(
     struct Longtail_HashAPI* hash_api,
     uint32_t tag,
     uint32_t chunk_count,
-    const uint64_t* chunk_indexes,
+    const uint32_t* chunk_indexes,
     const TLongtail_Hash* chunk_hashes,
     const uint32_t* chunk_sizes,
     struct Longtail_BlockIndex** out_block_index);
@@ -1430,7 +1430,7 @@ LONGTAIL_EXPORT size_t Longtail_GetStoreIndexSize(uint32_t block_count, uint32_t
 
 LONGTAIL_EXPORT int Longtail_CreateStoreIndex(
     struct Longtail_HashAPI* hash_api,
-    uint64_t chunk_count,
+    uint32_t chunk_count,
     const TLongtail_Hash* chunk_hashes,
     const uint32_t* chunk_sizes,
     const uint32_t* optional_chunk_tags,

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -1359,19 +1359,6 @@ LONGTAIL_EXPORT int Longtail_ReadStoredBlock(
     const char* path,
     struct Longtail_StoredBlock** out_stored_block);
 
-/*! @brief Validate that content_index contains all of version_index.
- *
- * Validates that all chunks required for @p version_index are present in @p store_index
- * Validates that reconstructing an asset via chunks results in the same size as recorded in @p version_index
- *
- * @param[in] store_index           The store index to validate
- * @param[in] version_index         The version index used to validate the content of @p store_index
- * @return                          Return code (errno style), zero on success. Success is when all content required is present
- */
-LONGTAIL_EXPORT int Longtail_ValidateStore(
-    const struct Longtail_StoreIndex* store_index,
-    const struct Longtail_VersionIndex* version_index);
-
 struct Longtail_BlockIndex
 {
     TLongtail_Hash* m_BlockHash;
@@ -1445,6 +1432,16 @@ LONGTAIL_EXPORT const uint32_t* Longtail_StoreIndex_GetChunkSizes(const struct L
 
 LONGTAIL_EXPORT size_t Longtail_GetStoreIndexSize(uint32_t block_count, uint32_t chunk_count);
 
+LONGTAIL_EXPORT int Longtail_CreateStoreIndex(
+    struct Longtail_HashAPI* hash_api,
+    uint64_t chunk_count,
+    const TLongtail_Hash* chunk_hashes,
+    const uint32_t* chunk_sizes,
+    const uint32_t* optional_chunk_tags,
+    uint32_t max_block_size,
+    uint32_t max_chunks_per_block,
+    struct Longtail_StoreIndex** out_store_index);
+
 LONGTAIL_EXPORT int Longtail_CreateStoreIndexFromBlocks(
     uint32_t block_count,
     const struct Longtail_BlockIndex** block_indexes,
@@ -1468,6 +1465,19 @@ LONGTAIL_EXPORT int Longtail_GetExistingStoreIndex(
     uint32_t max_block_size,
     uint32_t max_chunks_per_block,
     struct Longtail_StoreIndex** out_store_index);
+
+/*! @brief Validate that content_index contains all of version_index.
+ *
+ * Validates that all chunks required for @p version_index are present in @p store_index
+ * Validates that reconstructing an asset via chunks results in the same size as recorded in @p version_index
+ *
+ * @param[in] store_index           The store index to validate
+ * @param[in] version_index         The version index used to validate the content of @p store_index
+ * @return                          Return code (errno style), zero on success. Success is when all content required is present
+ */
+LONGTAIL_EXPORT int Longtail_ValidateStore(
+    const struct Longtail_StoreIndex* store_index,
+    const struct Longtail_VersionIndex* version_index);
 
 /*! @brief Copies a struct Longtail_StoreIndex.
  *

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -174,7 +174,7 @@ struct TestAsyncGetExistingContentComplete
     Longtail_StoreIndex* m_StoreIndex;
 };
 
-static struct Longtail_StoreIndex* SyncGetExistingContent(Longtail_BlockStoreAPI* block_store, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent)
+static struct Longtail_StoreIndex* SyncGetExistingContent(Longtail_BlockStoreAPI* block_store, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent)
 {
     TestAsyncGetExistingContentComplete get_existing_content_content_index_complete;
     if (block_store->GetExistingContent(block_store, chunk_count, chunk_hashes, min_block_usage_percent, &get_existing_content_content_index_complete.m_API))
@@ -361,7 +361,7 @@ TEST(Longtail, Longtail_CreateBlockIndex)
 {
     struct Longtail_HashAPI* hash_api = Longtail_CreateMeowHashAPI();
     ASSERT_NE((struct Longtail_HashAPI*)0, hash_api);
-    const uint64_t chunk_indexes[2] = {0, 1};
+    const uint32_t chunk_indexes[2] = {0, 1};
     const TLongtail_Hash chunk_hashes[2] = {0xdeadbeeffeed5a17, 0xfeed5a17deadbeef};
     const uint32_t chunk_sizes[2] = {4711, 1147};
     struct Longtail_BlockIndex* block_index;
@@ -388,7 +388,7 @@ TEST(Longtail, Longtail_ReadWriteBlockIndexInBuffer)
 {
     struct Longtail_HashAPI* hash_api = Longtail_CreateMeowHashAPI();
     ASSERT_NE((struct Longtail_HashAPI*)0, hash_api);
-    const uint64_t chunk_indexes[2] = {0, 1};
+    const uint32_t chunk_indexes[2] = {0, 1};
     const TLongtail_Hash chunk_hashes[2] = {0xdeadbeeffeed5a17, 0xfeed5a17deadbeef};
     const uint32_t chunk_sizes[2] = {4711, 1147};
     struct Longtail_BlockIndex* block_index;
@@ -571,7 +571,7 @@ TEST(Longtail, Longtail_CreateStoreIndexFromBlocks)
 {
     struct Longtail_HashAPI* hash_api = Longtail_CreateMeowHashAPI();
     ASSERT_NE((struct Longtail_HashAPI*)0, hash_api);
-    const uint64_t chunk_indexes[4] = {0, 1, 2, 3};
+    const uint32_t chunk_indexes[4] = {0, 1, 2, 3};
     const TLongtail_Hash chunk_hashes[4] = {0xdeadbeeffeed5a17, 0xfeed5a17deadbeef, 0xaeed5a17deadbeea, 0xdaedbeeffeed5a57};
     const uint32_t chunk_sizes[4] = {4711, 1147, 1137, 3219};
     struct Longtail_BlockIndex* block_index1;
@@ -647,7 +647,7 @@ TEST(Longtail, Longtail_MergeStoreIndexWithEmpty)
 {
     struct Longtail_HashAPI* hash_api = Longtail_CreateMeowHashAPI();
     ASSERT_NE((struct Longtail_HashAPI*)0, hash_api);
-    const uint64_t chunk_indexes[5] = {0, 1, 2, 3, 4};
+    const uint32_t chunk_indexes[5] = {0, 1, 2, 3, 4};
     const TLongtail_Hash chunk_hashes[5] = {0xdeadbeeffeed5a17, 0xfeed5a17deadbeef, 0xaeed5a17deadbeea, 0xdaedbeeffeed5a57, 0xfeed5a17deadbeef};
     const uint32_t chunk_sizes[5] = {4711, 1147, 1137, 3219, 1147};
     struct Longtail_BlockIndex* block_index1;
@@ -710,7 +710,7 @@ TEST(Longtail, Longtail_MergeStoreIndex)
 {
     struct Longtail_HashAPI* hash_api = Longtail_CreateMeowHashAPI();
     ASSERT_NE((struct Longtail_HashAPI*)0, hash_api);
-    const uint64_t chunk_indexes[5] = {0, 1, 2, 3, 4};
+    const uint32_t chunk_indexes[5] = {0, 1, 2, 3, 4};
     const TLongtail_Hash chunk_hashes[5] = {0xdeadbeeffeed5a17, 0xfeed5a17deadbeef, 0xaeed5a17deadbeea, 0xdaedbeeffeed5a57, 0xfeed5a17deadbeef};
     const uint32_t chunk_sizes[5] = {4711, 1147, 1137, 3219, 1147};
     struct Longtail_BlockIndex* block_index1;
@@ -780,7 +780,7 @@ TEST(Longtail, Longtail_CreateStoreIndexFromContentIndex)
 {
     struct Longtail_HashAPI* hash_api = Longtail_CreateMeowHashAPI();
     ASSERT_NE((struct Longtail_HashAPI*)0, hash_api);
-    const uint64_t chunk_indexes[4] = {0, 1, 2, 3};
+    const uint32_t chunk_indexes[4] = {0, 1, 2, 3};
     const TLongtail_Hash chunk_hashes[4] = {0xdeadbeeffeed5a17, 0xfeed5a17deadbeef, 0xaeed5a17deadbeea, 0xdaedbeeffeed5a57};
     const uint32_t chunk_sizes[4] = {4711, 1147, 1137, 3219};
     struct Longtail_BlockIndex* block_index1;
@@ -2415,14 +2415,14 @@ TEST(Longtail, EmptyFolderGetRequiredChunkHashes)
             &zero
         };
 
-    uint64_t required_chunk_count = 4711;
+    uint32_t required_chunk_count = 4711;
     TLongtail_Hash* required_chunk_hashes = 0;
     ASSERT_EQ(0, Longtail_GetRequiredChunkHashes(
             version_index,
             &version_diff,
             &required_chunk_count,
             required_chunk_hashes));
-    ASSERT_EQ((uint64_t)0, required_chunk_count);
+    ASSERT_EQ((uint32_t)0, required_chunk_count);
 
     Longtail_Free(version_index);
     Longtail_Free(file_infos);
@@ -2744,7 +2744,7 @@ TEST(Longtail, Longtail_VersionDiff)
     ASSERT_EQ(6u, *version_diff->m_ModifiedContentCount);
     ASSERT_EQ(1u, *version_diff->m_ModifiedPermissionsCount);
 
-    uint64_t required_chunk_count;
+    uint32_t required_chunk_count;
     TLongtail_Hash* required_chunk_hashes = (TLongtail_Hash*)Longtail_Alloc(0, sizeof(TLongtail_Hash) * (*new_vindex->m_ChunkCount));
     ASSERT_EQ(0, Longtail_GetRequiredChunkHashes(
             new_vindex,
@@ -3293,7 +3293,7 @@ struct TestGetBlockRequest
 struct TestGetExistingContentRequest
 {
     struct Longtail_AsyncGetExistingContentAPI* async_complete_api;
-    uint64_t chunk_count;
+    uint32_t chunk_count;
     TLongtail_Hash* chunk_hashes;
 };
 
@@ -3311,11 +3311,11 @@ public:
     static int InitBlockStore(TestAsyncBlockStore* block_store, struct Longtail_HashAPI* hash_api, struct Longtail_JobAPI* job_api);
     static void Dispose(struct Longtail_API* api);
     static int PutStoredBlock(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_StoredBlock* stored_block, struct Longtail_AsyncPutStoredBlockAPI* async_complete_api);
-    static int PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes);
+    static int PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes);
     static int GetStoredBlock(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_hash, struct Longtail_AsyncGetStoredBlockAPI* async_complete_api);
     static int GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats);
     static int Flush(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_AsyncFlushAPI* async_complete_api);
-    static int GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api);
+    static int GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api);
     static void CompleteRequest(class TestAsyncBlockStore* block_store);
 private:
     struct Longtail_HashAPI* m_HashAPI;
@@ -3688,7 +3688,7 @@ int TestAsyncBlockStore::PutStoredBlock(struct Longtail_BlockStoreAPI* block_sto
     return 0;
 }
 
-int TestAsyncBlockStore::PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes)
+int TestAsyncBlockStore::PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes)
 {
     return 0;
 }
@@ -3717,7 +3717,7 @@ int TestAsyncBlockStore::GetStoredBlock(struct Longtail_BlockStoreAPI* block_sto
     return 0;
 }
 
-int TestAsyncBlockStore::GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api)
+int TestAsyncBlockStore::GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(block_store_api, "%p"),
@@ -4754,7 +4754,7 @@ TEST(Longtail, TestChangeVersionCancelOperation)
         &version_diff));
     ASSERT_NE((Longtail_VersionDiff*)0, version_diff);
 
-    uint64_t required_chunk_count;
+    uint32_t required_chunk_count;
     TLongtail_Hash* required_chunk_hashes = (TLongtail_Hash*)Longtail_Alloc(0, sizeof(TLongtail_Hash) * (*vindex->m_ChunkCount));
     ASSERT_EQ(0, Longtail_GetRequiredChunkHashes(
             vindex,
@@ -4780,7 +4780,7 @@ TEST(Longtail, TestChangeVersionCancelOperation)
             struct BlockStoreProxy* api = (struct BlockStoreProxy*)block_store_api;
             return api->m_Base->PutStoredBlock(api->m_Base, stored_block, async_complete_api);
         }
-        static int PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes)
+        static int PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes)
         {
             struct BlockStoreProxy* api = (struct BlockStoreProxy*)block_store_api;
             return api->m_Base->PreflightGet(api->m_Base, chunk_count, chunk_hashes);
@@ -4794,7 +4794,7 @@ TEST(Longtail, TestChangeVersionCancelOperation)
             }
             return api->m_Base->GetStoredBlock(api->m_Base, block_hash, async_complete_api);
         }
-        static int GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api)
+        static int GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api)
         {
             MAKE_LOG_CONTEXT_FIELDS(ctx)
                 LONGTAIL_LOGFIELD(block_store_api, "%p"),
@@ -5436,7 +5436,7 @@ TEST(Longtail, TestChangeVersionDiskFull)
         &version_diff));
     ASSERT_NE((Longtail_VersionDiff*)0, version_diff);
 
-    uint64_t required_chunk_count;
+    uint32_t required_chunk_count;
     TLongtail_Hash* required_chunk_hashes = (TLongtail_Hash*)Longtail_Alloc(0, sizeof(TLongtail_Hash) * (*vindex->m_ChunkCount));
     ASSERT_EQ(0, Longtail_GetRequiredChunkHashes(
             vindex,
@@ -6061,7 +6061,7 @@ static int DownloadFolder(
         return err;
     }
 
-    uint64_t required_chunk_count;
+    uint32_t required_chunk_count;
     TLongtail_Hash* required_chunk_hashes = (TLongtail_Hash*)Longtail_Alloc(0, sizeof(TLongtail_Hash) * (*version_index->m_ChunkCount));
     err = Longtail_GetRequiredChunkHashes(
             version_index,
@@ -6210,7 +6210,7 @@ static int CaptureBlockStore_PutStoredBlock(struct Longtail_BlockStoreAPI* block
     return api->m_BackingStore->PutStoredBlock(api->m_BackingStore, stored_block, async_complete_api);
 }
 
-static int CaptureBlockStore_PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes)
+static int CaptureBlockStore_PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes)
 {
     struct CaptureBlockStore* api = (struct CaptureBlockStore*)block_store_api;
 
@@ -6234,7 +6234,7 @@ static int CaptureBlockStore_GetStoredBlock(struct Longtail_BlockStoreAPI* block
     return api->m_BackingStore->GetStoredBlock(api->m_BackingStore, block_hash, async_complete_api);
 }
 
-static int CaptureBlockStore_GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint64_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api)
+static int CaptureBlockStore_GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api)
 {
     struct CaptureBlockStore* api = (struct CaptureBlockStore*)block_store_api;
     return api->m_BackingStore->GetExistingContent(api->m_BackingStore, chunk_count, chunk_hashes, min_block_usage_percent, async_complete_api);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1198,11 +1198,14 @@ TEST(Longtail, ContentIndexSerialization)
     Longtail_Free(vindex);
     vindex = 0;
 
-    ASSERT_EQ(0, Longtail_WriteContentIndex(local_storage, cindex, "cindex.lci"));
+    size_t buf_size;
+    void* buf;
+    ASSERT_EQ(0, Longtail_WriteContentIndexToBuffer(cindex, &buf, &buf_size));
 
     Longtail_ContentIndex* cindex2;
-    ASSERT_EQ(0, Longtail_ReadContentIndex(local_storage, "cindex.lci", &cindex2));
+    ASSERT_EQ(0, Longtail_ReadContentIndexFromBuffer(buf, buf_size, &cindex2));
     ASSERT_NE((Longtail_ContentIndex*)0, cindex2);
+    Longtail_Free(buf);
 
     ASSERT_EQ(*cindex->m_BlockCount, *cindex2->m_BlockCount);
     for (uint64_t i = 0; i < *cindex->m_BlockCount; ++i)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -948,8 +948,6 @@ TEST(Longtail, Longtail_GetExistingStoreIndex)
         (uint32_t)arrlen(chunk_hashes),
         chunk_hashes,
         0,
-        32 * block_count,
-        5,
         &all_blocks));
     ASSERT_EQ(6, *all_blocks->m_BlockCount);
     ASSERT_EQ(*block_indexes[4]->m_BlockHash, all_blocks->m_BlockHashes[0]);
@@ -966,8 +964,6 @@ TEST(Longtail, Longtail_GetExistingStoreIndex)
         (uint32_t)arrlen(chunk_hashes),
         chunk_hashes,
         100,
-        32 * 5,
-        5,
         &all_full_blocks));
     ASSERT_EQ(1, *all_full_blocks->m_BlockCount);
     ASSERT_EQ(*block_indexes[4]->m_BlockHash, all_full_blocks->m_BlockHashes[0]);
@@ -979,8 +975,6 @@ TEST(Longtail, Longtail_GetExistingStoreIndex)
         (uint32_t)arrlen(chunk_hashes),
         chunk_hashes,
         50,
-        32 * 5,
-        5,
         &half_full_blocks));
     ASSERT_EQ(3, *half_full_blocks->m_BlockCount);
     ASSERT_EQ(*block_indexes[4]->m_BlockHash, half_full_blocks->m_BlockHashes[0]);
@@ -994,8 +988,6 @@ TEST(Longtail, Longtail_GetExistingStoreIndex)
         (uint32_t)arrlen(chunk_hashes),
         chunk_hashes,
         2 * (100 / 5),
-        32 * 5,
-        5,
         &less_full_blocks));
     ASSERT_EQ(5, *less_full_blocks->m_BlockCount);
     ASSERT_EQ(*block_indexes[4]->m_BlockHash, less_full_blocks->m_BlockHashes[0]);
@@ -1011,8 +1003,6 @@ TEST(Longtail, Longtail_GetExistingStoreIndex)
         (uint32_t)arrlen(chunk_hashes),
         chunk_hashes,
         101,
-        32 * 5,
-        5,
         &no_blocks));
     ASSERT_EQ(0, *no_blocks->m_BlockCount);
     Longtail_Free(no_blocks);
@@ -3637,8 +3627,6 @@ int TestAsyncBlockStore::Worker(void* context_data)
                 (uint32_t)get_existing_content_content_request->chunk_count,
                 get_existing_content_content_request->chunk_hashes,
                 0,
-                MAX_BLOCK_SIZE,
-                MAX_CHUNKS_PER_BLOCK,
                 &store_index);
             Longtail_UnlockSpinLock(block_store->m_IndexLock);
             Longtail_Free(get_existing_content_content_request->chunk_hashes);


### PR DESCRIPTION
Replace all usage of `Longtail_ContentIndex` with `Longtail_StoreIndex`.

- **CHANGED** Reworked/simplified logic in MergeStoreIndex
- **CHANGED** Sounder hash identifier check in Longtail_MergeStoreIndex()
- **FIX** Test for CopyBlockIndex
- **FIX** Test for CopyStoreIndex
- **FIX** Don't assume stuff about memory layout of StoreIndex and BlockIndex
- **FIX** Graceful fail instead of assert on bad store index
- **FIX** Use uint64_t for stats in memtracer (fixes print formatting warnings)
- **CHANGED API**
  - `Longtail_AsyncGetExistingContentAPI`
  - `Longtail_BlockStore_PreflightGetFunc`
  - `Longtail_BlockStore_GetExistingContentFunc`
  - `Longtail_GetRequiredChunkHashes`
  - `Longtail_WriteContent`
  - `Longtail_WriteContent`
  - `Longtail_CreateMissingContent`
  - `Longtail_GetMissingChunks`
  - `Longtail_AddContentIndex`
  - `Longtail_CreateVersionDiff`
  - `Longtail_ChangeVersion`
  - `Longtail_InitBlockIndexFromData`
- **REMOVED API** Remove all `Longtail_ContentIndex` types and functions
  - `struct Longtail_ContentIndex`
  - `Longtail_GetContentIndexDataSize`
  - `Longtail_GetContentIndexSize`
  - `Longtail_InitContentIndexFromData`
  - `Longtail_InitContentIndex`
  - `Longtail_CreateContentIndexFromBlocks`
  - `Longtail_CreateContentIndex`
  - `Longtail_CreateContentIndexRaw`
  - `Longtail_CreateContentIndexFromStoreIndex`
  - `Longtail_WriteContentIndexToBuffer`
  - `Longtail_ReadContentIndexFromBuffer`
  - `Longtail_WriteContentIndex`
  - `Longtail_ReadContentIndex`
  - `Longtail_MergeContentIndex`
  - `Longtail_ValidateContent`
  - `Longtail_ValidateVersion`
  - `Longtail_ContentIndex_GetVersion`
  - `Longtail_ContentIndex_GetHashAPI`
  - `Longtail_ContentIndex_GetBlockCount`
  - `Longtail_ContentIndex_GetChunkCount`
  - `Longtail_CreateStoreIndexFromContentIndex`
  - `Longtail_GetExistingContentIndex`
- **ADDED API**
  - `Longtail_CreateStoreIndex`
  - `Longtail_GetExistingStoreIndex`
  - `Longtail_ValidateStore`
  - `Longtail_VersionIndex_GetChunkHashes`
  - `Longtail_VersionIndex_GetChunkSizes`
  - `Longtail_VersionIndex_GetChunkTags`
- **REMOVED** `--version-content-index-path` option has been removed from command line tool
