### PR TITLE
Added API for BlockStore::PruneBlocks

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -108,7 +108,7 @@ jobs:
           - **CHANGED API** `Longtail_BlockStore_Stats` has three new fields `Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count`, `Longtail_BlockStoreAPI_StatU64_PruneBlocks_RetryCount` and `Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount`
           - **ADDED** `Longtail_PruneStoreIndex` function added to remove blocks from a store index
         draft: false
-        prerelease: false
+        prerelease: true
     - name: Download Linux artifacts
       uses: actions/download-artifact@v1
       with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -106,6 +106,7 @@ jobs:
           # Changes in this Release
           - **CHANGED API** `Longtail_BlockStoreAPI` has new function `PruneBlocks`
           - **CHANGED API** `Longtail_BlockStore_Stats` has three new fields `Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count`, `Longtail_BlockStoreAPI_StatU64_PruneBlocks_RetryCount` and `Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount`
+          - **ADDED** `Longtail_PruneStoreIndex` function added to remove blocks from a store index
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -104,10 +104,8 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           # Changes in this Release
-          - **CHANGED API** `Longtail_CreateFSBlockStoreAPI` not longer takes `default_max_block_size` and `default_max_chunks_per_block`
-          - **CHANGED** Fixed includes for `alloca` and `CompareIgnoreCase` to build under Cygwin
-          - **CHANGED** Prefer blocks based on how much of the block is used rather than how much data is used in a block
-          - **FIXED** Only sort and consider blocks that has any matching usage
+          - **CHANGED API** `Longtail_BlockStoreAPI` has new function `PruneBlocks`
+          - **CHANGED API** `Longtail_BlockStore_Stats` has three new fields `Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count`, `Longtail_BlockStoreAPI_StatU64_PruneBlocks_RetryCount` and `Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount`
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -108,7 +108,7 @@ jobs:
           - **CHANGED API** `Longtail_BlockStore_Stats` has three new fields `Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count`, `Longtail_BlockStoreAPI_StatU64_PruneBlocks_RetryCount` and `Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount`
           - **ADDED** `Longtail_PruneStoreIndex` function added to remove blocks from a store index
         draft: false
-        prerelease: true
+        prerelease: false
     - name: Download Linux artifacts
       uses: actions/download-artifact@v1
       with:

--- a/lib/cacheblockstore/longtail_cacheblockstore.c
+++ b/lib/cacheblockstore/longtail_cacheblockstore.c
@@ -830,6 +830,32 @@ static int CacheBlockStore_GetExistingContent(
     return 0;
 }
 
+static int CacheBlockStore_PruneBlocks(
+    struct Longtail_BlockStoreAPI* block_store_api,
+    uint32_t block_keep_count,
+    const TLongtail_Hash* block_keep_hashes,
+    struct Longtail_AsyncPruneBlocksAPI* async_complete_api)
+{
+    MAKE_LOG_CONTEXT_FIELDS(ctx)
+        LONGTAIL_LOGFIELD(block_store_api, "%p"),
+        LONGTAIL_LOGFIELD(block_keep_count, "%u"),
+        LONGTAIL_LOGFIELD(block_keep_hashes, "%p"),
+        LONGTAIL_LOGFIELD(async_complete_api, "%p")
+    MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_INFO)
+
+    LONGTAIL_VALIDATE_INPUT(ctx, block_store_api, return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(ctx, (block_keep_count == 0) || (block_keep_hashes != 0), return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(ctx, async_complete_api, return EINVAL)
+
+    struct CacheBlockStoreAPI* api = (struct CacheBlockStoreAPI*)block_store_api;
+
+    Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
+
+    async_complete_api->OnComplete(async_complete_api, 0, 0);
+
+    return 0;
+}
+
 static int CacheBlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
@@ -919,6 +945,7 @@ static int CacheBlockStore_Init(
         CacheBlockStore_PreflightGet,
         CacheBlockStore_GetStoredBlock,
         CacheBlockStore_GetExistingContent,
+        CacheBlockStore_PruneBlocks,
         CacheBlockStore_GetStats,
         CacheBlockStore_Flush);
     if (!block_store_api)

--- a/lib/cacheblockstore/longtail_cacheblockstore.c
+++ b/lib/cacheblockstore/longtail_cacheblockstore.c
@@ -830,6 +830,40 @@ static int CacheBlockStore_GetExistingContent(
     return 0;
 }
 
+struct PruneBlocks_Context
+{
+    struct Longtail_AsyncPruneBlocksAPI m_AsyncCompleteAPI;
+    struct CacheBlockStoreAPI* m_CacheBlockStoreAPI;
+    struct Longtail_AsyncPruneBlocksAPI* m_FinalAsyncCompleteAPI;
+    uint32_t block_keep_count;
+    TLongtail_Hash* block_keep_hashes;
+    TLongtail_Atomic64 pruned_block_count;
+    TLongtail_Atomic32 pending_complete_callbacks;
+    int err;
+};
+
+static void CacheBlockStore_PruneBlocks_OnComplete(struct Longtail_AsyncPruneBlocksAPI* async_complete_api, uint32_t pruned_block_count, int err)
+{
+    struct PruneBlocks_Context* context = (struct PruneBlocks_Context*)async_complete_api;
+    if (err)
+    {
+        context->err = err;
+    }
+    if (0 == Longtail_AtomicAdd32(&context->pending_complete_callbacks, -1))
+    {
+        if (context->err == 0)
+        {
+            Longtail_AtomicAdd64(&context->m_CacheBlockStoreAPI->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
+        }
+        else
+        {
+            Longtail_AtomicAdd64(&context->m_CacheBlockStoreAPI->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
+        }
+        context->m_FinalAsyncCompleteAPI->OnComplete(context->m_FinalAsyncCompleteAPI, (uint32_t)pruned_block_count, context->err);
+        Longtail_Free(context);
+    }
+}
+
 static int CacheBlockStore_PruneBlocks(
     struct Longtail_BlockStoreAPI* block_store_api,
     uint32_t block_keep_count,
@@ -849,9 +883,36 @@ static int CacheBlockStore_PruneBlocks(
 
     struct CacheBlockStoreAPI* api = (struct CacheBlockStoreAPI*)block_store_api;
 
-    Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
+    size_t context_size = sizeof(struct PruneBlocks_Context) + sizeof(TLongtail_Hash) * block_keep_count;
+    struct PruneBlocks_Context* context = (struct PruneBlocks_Context*)Longtail_Alloc("CacheBlockStore_PruneBlocks", context_size);
+    context->m_AsyncCompleteAPI.m_API.Dispose = 0;
+    context->m_AsyncCompleteAPI.OnComplete = CacheBlockStore_PruneBlocks_OnComplete;
+    context->m_CacheBlockStoreAPI = api;
+    context->m_FinalAsyncCompleteAPI = async_complete_api;
+    context->block_keep_count = block_keep_count;
+    context->block_keep_hashes = (TLongtail_Hash*)&context[1];
+    context->pruned_block_count = 0;
+    context->pending_complete_callbacks = 2;
 
-    async_complete_api->OnComplete(async_complete_api, 0, 0);
+    for (uint32_t b = 0; b < block_keep_count; ++b)
+    {
+        context->block_keep_hashes[b] = block_keep_hashes[b];
+    }
+
+    int err = api->m_LocalBlockStoreAPI->PruneBlocks(api->m_LocalBlockStoreAPI, context->block_keep_count, context->block_keep_hashes, &context->m_AsyncCompleteAPI);
+    if (err != 0)
+    {
+        Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
+        Longtail_Free(context);
+        return err;
+    }
+
+    err = api->m_LocalBlockStoreAPI->PruneBlocks(api->m_RemoteBlockStoreAPI, context->block_keep_count, context->block_keep_hashes, &context->m_AsyncCompleteAPI);
+    if (err != 0)
+    {
+        CacheBlockStore_PruneBlocks_OnComplete(&context->m_AsyncCompleteAPI, 0, err);
+        return 0;
+    }
 
     return 0;
 }

--- a/lib/compressblockstore/longtail_compressblockstore.c
+++ b/lib/compressblockstore/longtail_compressblockstore.c
@@ -509,22 +509,7 @@ static int CompressBlockStore_PruneBlocks(
     LONGTAIL_VALIDATE_INPUT(ctx, (block_keep_count == 0) || (block_keep_hashes != 0), return EINVAL)
     LONGTAIL_VALIDATE_INPUT(ctx, async_complete_api, return EINVAL)
 
-    struct CompressBlockStoreAPI* api = (struct CompressBlockStoreAPI*)block_store_api;
-
-    Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
-
-    int err = api->m_BackingBlockStore->PruneBlocks(
-        api->m_BackingBlockStore,
-        block_keep_count,
-        block_keep_hashes,
-        async_complete_api);
-    if (err)
-    {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "api->m_BackingBlockStore->PruneBlocks() failed with %d", err)
-        Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
-        return err;
-    }
-    return 0;
+    return ENOTSUP;
 }
 
 static int CompressBlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats)

--- a/lib/fsblockstore/longtail_fsblockstore.c
+++ b/lib/fsblockstore/longtail_fsblockstore.c
@@ -1153,6 +1153,7 @@ static int FSBlockStore_PruneBlocks(
             Longtail_Free((void*)block_path);
             hmdel(api->m_BlockState, block_hash);
         }
+        Longtail_Free(kept_block_lookup_mem);
     }
 
     api->m_StorageAPI->UnlockFile(api->m_StorageAPI, store_index_lock_file);

--- a/lib/fsblockstore/longtail_fsblockstore.c
+++ b/lib/fsblockstore/longtail_fsblockstore.c
@@ -1048,10 +1048,113 @@ static int FSBlockStore_PruneBlocks(
     LONGTAIL_VALIDATE_INPUT(ctx, async_complete_api, return EINVAL)
 
     struct FSBlockStoreAPI* api = (struct FSBlockStoreAPI*)block_store_api;
+    Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
+    struct Longtail_StoreIndex* store_index;
+    int err = FSBlockStore_GetIndexSync(api, &store_index);
+    if (err)
+    {
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "FSBlockStore_GetIndexSync() failed with %d", err)
+        Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
+        return err;
+    }
+
+    // We have a gap here where the index on disk *could* change from another Flush operation
+    // Pruning while other process/task is writing or pruning to the same disk database is not supported
+
+    Longtail_StorageAPI_HLockFile store_index_lock_file;
+    err = api->m_StorageAPI->LockFile(api->m_StorageAPI, api->m_StoreIndexLockPath, &store_index_lock_file);
+    if (err)
+    {
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "m_StorageAPI->LockFile() failed with %d", err)
+        Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
+        Longtail_Free(store_index);
+        return err;
+    }
+
+    struct Longtail_StoreIndex* pruned_store_index;
+    err = Longtail_PruneStoreIndex(
+        store_index,
+        block_keep_count,
+        block_keep_hashes,
+        &pruned_store_index);
+    if (err != 0)
+    {
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Longtail_PruneStoreIndex() failed with %d", err)
+        api->m_StorageAPI->UnlockFile(api->m_StorageAPI, store_index_lock_file);
+        Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
+        Longtail_Free(store_index);
+        return err;
+    }
+
+    if (api->m_StoreIndex != pruned_store_index)
+    {
+        Longtail_Free(api->m_StoreIndex);
+        api->m_StoreIndex = pruned_store_index;
+    }
+    api->m_StoreIndexIsDirty = 0;
+
+    err = SafeWriteStoreIndex(api);
+    if (err != 0) {
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "SafeWriteStoreIndex() failed with %d", err)
+        api->m_StorageAPI->UnlockFile(api->m_StorageAPI, store_index_lock_file);
+        Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
+        Longtail_Free(store_index);
+        return err;
+    }
+
+    uint32_t old_block_count = *store_index->m_BlockCount;
+    uint32_t block_count = *pruned_store_index->m_BlockCount;
+    uint32_t pruned_count = *store_index->m_BlockCount - block_count;
+    if (pruned_count > 0)
+    {
+        size_t kept_block_lookup_size = Longtail_LookupTable_GetSize(block_count);
+        void* kept_block_lookup_mem = Longtail_Alloc("FSBlockStore_PruneBlocks", kept_block_lookup_size);
+        if (kept_block_lookup_mem == 0)
+        {
+            LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Longtail_Alloc() failed with %d", err)
+            api->m_StorageAPI->UnlockFile(api->m_StorageAPI, store_index_lock_file);
+            Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
+            Longtail_Free(store_index);
+            return err;
+        }
+        struct Longtail_LookupTable* kept_block_lookup = Longtail_LookupTable_Create(kept_block_lookup_mem, block_count, 0);
+        for (uint32_t b = 0; b < block_count; ++b)
+        {
+            TLongtail_Hash block_hash = pruned_store_index->m_BlockHashes[b];
+            Longtail_LookupTable_PutUnique(kept_block_lookup, block_hash, b);
+        }
+
+        for (uint32_t b = 0; b < old_block_count; ++b)
+        {
+            TLongtail_Hash block_hash = store_index->m_BlockHashes[b];
+            if (Longtail_LookupTable_Get(kept_block_lookup, block_hash))
+            {
+                continue;
+            }
+            char* block_path = GetBlockPath(api->m_StorageAPI, api->m_StorePath, api->m_BlockExtension, block_hash);
+
+            // Check if block exists, if it does it is just the store store index that is out of sync.
+            // Don't write the block unless we have to
+            if (!api->m_StorageAPI->IsFile(api->m_StorageAPI, block_path))
+            {
+                Longtail_Free((void*)block_path);
+                continue;
+            }
+            err = api->m_StorageAPI->RemoveFile(api->m_StorageAPI, block_path);
+            if (err != 0)
+            {
+                LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "FSBlockStore_PruneBlocks() failed to remove file `%s`, error %d", block_path, err);
+            }
+            Longtail_Free((void*)block_path);
+        }
+    }
+
+    api->m_StorageAPI->UnlockFile(api->m_StorageAPI, store_index_lock_file);
+    Longtail_Free(store_index);
 
     Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
 
-    async_complete_api->OnComplete(async_complete_api, 0, 0);
+    async_complete_api->OnComplete(async_complete_api, pruned_count, 0);
 
     return 0;
 }

--- a/lib/fsblockstore/longtail_fsblockstore.c
+++ b/lib/fsblockstore/longtail_fsblockstore.c
@@ -1030,6 +1030,32 @@ static int FSBlockStore_GetExistingContent(
     return 0;
 }
 
+static int FSBlockStore_PruneBlocks(
+    struct Longtail_BlockStoreAPI* block_store_api,
+    uint32_t block_keep_count,
+    const TLongtail_Hash* block_keep_hashes,
+    struct Longtail_AsyncPruneBlocksAPI* async_complete_api)
+{
+    MAKE_LOG_CONTEXT_FIELDS(ctx)
+        LONGTAIL_LOGFIELD(block_store_api, "%p"),
+        LONGTAIL_LOGFIELD(block_keep_count, "%u"),
+        LONGTAIL_LOGFIELD(block_keep_hashes, "%p"),
+        LONGTAIL_LOGFIELD(async_complete_api, "%p")
+    MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_INFO)
+
+    LONGTAIL_VALIDATE_INPUT(ctx, block_store_api, return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(ctx, (block_keep_count == 0) || (block_keep_hashes != 0), return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(ctx, async_complete_api, return EINVAL)
+
+    struct FSBlockStoreAPI* api = (struct FSBlockStoreAPI*)block_store_api;
+
+    Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
+
+    async_complete_api->OnComplete(async_complete_api, 0, 0);
+
+    return 0;
+}
+
 static int FSBlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
@@ -1171,6 +1197,7 @@ static int FSBlockStore_Init(
         FSBlockStore_PreflightGet,
         FSBlockStore_GetStoredBlock,
         FSBlockStore_GetExistingContent,
+        FSBlockStore_PruneBlocks,
         FSBlockStore_GetStats,
         FSBlockStore_Flush);
     if (!block_store_api)

--- a/lib/lrublockstore/longtail_lrublockstore.c
+++ b/lib/lrublockstore/longtail_lrublockstore.c
@@ -562,22 +562,7 @@ static int LRUBlockStore_PruneBlocks(
     LONGTAIL_VALIDATE_INPUT(ctx, (block_keep_count == 0) || (block_keep_hashes != 0), return EINVAL)
     LONGTAIL_VALIDATE_INPUT(ctx, async_complete_api, return EINVAL)
 
-    struct LRUBlockStoreAPI* api = (struct LRUBlockStoreAPI*)block_store_api;
-
-    Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
-
-    int err = api->m_BackingBlockStore->PruneBlocks(
-        api->m_BackingBlockStore,
-        block_keep_count,
-        block_keep_hashes,
-        async_complete_api);
-    if (err)
-    {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "api->m_BackingBlockStore->PruneBlocks() failed with %d", err)
-        Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
-        return err;
-    }
-    return 0;
+    return ENOTSUP;
 }
 
 static int LRUBlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats)

--- a/lib/shareblockstore/longtail_shareblockstore.c
+++ b/lib/shareblockstore/longtail_shareblockstore.c
@@ -415,6 +415,41 @@ static int ShareBlockStore_GetExistingContent(
     return 0;
 }
 
+static int ShareBlockStore_PruneBlocks(
+    struct Longtail_BlockStoreAPI* block_store_api,
+    uint32_t block_keep_count,
+    const TLongtail_Hash* block_keep_hashes,
+    struct Longtail_AsyncPruneBlocksAPI* async_complete_api)
+{
+    MAKE_LOG_CONTEXT_FIELDS(ctx)
+        LONGTAIL_LOGFIELD(block_store_api, "%p"),
+        LONGTAIL_LOGFIELD(block_keep_count, "%u"),
+        LONGTAIL_LOGFIELD(block_keep_hashes, "%p"),
+        LONGTAIL_LOGFIELD(async_complete_api, "%p")
+    MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_INFO)
+
+    LONGTAIL_VALIDATE_INPUT(ctx, block_store_api, return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(ctx, (block_keep_count == 0) || (block_keep_hashes != 0), return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(ctx, async_complete_api, return EINVAL)
+
+    struct ShareBlockStoreAPI* api = (struct ShareBlockStoreAPI*)block_store_api;
+
+    Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
+
+    int err = api->m_BackingBlockStore->PruneBlocks(
+        api->m_BackingBlockStore,
+        block_keep_count,
+        block_keep_hashes,
+        async_complete_api);
+    if (err)
+    {
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "api->m_BackingBlockStore->PruneBlocks() failed with %d", err)
+        Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
+        return err;
+    }
+    return 0;
+}
+
 static int ShareBlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
@@ -501,6 +536,7 @@ static int ShareBlockStore_Init(
         ShareBlockStore_PreflightGet,
         ShareBlockStore_GetStoredBlock,
         ShareBlockStore_GetExistingContent,
+        ShareBlockStore_PruneBlocks,
         ShareBlockStore_GetStats,
         ShareBlockStore_Flush);
     if (!block_store_api)

--- a/lib/shareblockstore/longtail_shareblockstore.c
+++ b/lib/shareblockstore/longtail_shareblockstore.c
@@ -432,22 +432,7 @@ static int ShareBlockStore_PruneBlocks(
     LONGTAIL_VALIDATE_INPUT(ctx, (block_keep_count == 0) || (block_keep_hashes != 0), return EINVAL)
     LONGTAIL_VALIDATE_INPUT(ctx, async_complete_api, return EINVAL)
 
-    struct ShareBlockStoreAPI* api = (struct ShareBlockStoreAPI*)block_store_api;
-
-    Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count], 1);
-
-    int err = api->m_BackingBlockStore->PruneBlocks(
-        api->m_BackingBlockStore,
-        block_keep_count,
-        block_keep_hashes,
-        async_complete_api);
-    if (err)
-    {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "api->m_BackingBlockStore->PruneBlocks() failed with %d", err)
-        Longtail_AtomicAdd64(&api->m_StatU64[Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount], 1);
-        return err;
-    }
-    return 0;
+    return ENOTSUP;
 }
 
 static int ShareBlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats)

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -567,6 +567,33 @@ struct Longtail_AsyncGetExistingContentAPI* Longtail_MakeAsyncGetExistingContent
 
 void Longtail_AsyncGetExistingContent_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_StoreIndex* store_index, int err) { async_complete_api->OnComplete(async_complete_api, store_index, err); }
 
+////////////// AsyncPruneBlocksAPI
+
+uint64_t Longtail_GetAsyncPruneBlocksAPISize()
+{
+    return sizeof(struct Longtail_AsyncPruneBlocksAPI);
+}
+
+struct Longtail_AsyncPruneBlocksAPI* Longtail_MakeAsyncPruneBlocksAPI(
+    void* mem,
+    Longtail_DisposeFunc dispose_func,
+    Longtail_AsyncPruneBlocks_OnCompleteFunc on_complete_func)
+{
+    MAKE_LOG_CONTEXT_FIELDS(ctx)
+        LONGTAIL_LOGFIELD(mem, "%p"),
+        LONGTAIL_LOGFIELD(dispose_func, "%p"),
+        LONGTAIL_LOGFIELD(on_complete_func, "%p")
+    MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_INFO)
+
+    LONGTAIL_VALIDATE_INPUT(ctx, mem != 0, return 0)
+    struct Longtail_AsyncPruneBlocksAPI* api = (struct Longtail_AsyncPruneBlocksAPI*)mem;
+    api->m_API.Dispose = dispose_func;
+    api->OnComplete = on_complete_func;
+    return api;
+}
+
+void Longtail_AsyncPruneBlocks_OnComplete(struct Longtail_AsyncPruneBlocksAPI* async_complete_api, uint32_t pruned_block_count, int err) { async_complete_api->OnComplete(async_complete_api, pruned_block_count, err); }
+
 ////////////// Longtail_AsyncPreflightStartedAPI
 
 uint64_t Longtail_GetAsyncPreflightStartedAPISize()

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -636,6 +636,7 @@ struct Longtail_BlockStoreAPI* Longtail_MakeBlockStoreAPI(
     Longtail_BlockStore_PreflightGetFunc preflight_get_func,
     Longtail_BlockStore_GetStoredBlockFunc get_stored_block_func,
     Longtail_BlockStore_GetExistingContentFunc get_existing_content_func,
+    Longtail_BlockStore_PruneBlocksFunc prune_blocks_func,
     Longtail_BlockStore_GetStatsFunc get_stats_func,
     Longtail_BlockStore_FlushFunc flush_func)
 {
@@ -646,6 +647,7 @@ struct Longtail_BlockStoreAPI* Longtail_MakeBlockStoreAPI(
         LONGTAIL_LOGFIELD(preflight_get_func, "%p"),
         LONGTAIL_LOGFIELD(get_stored_block_func, "%p"),
         LONGTAIL_LOGFIELD(get_existing_content_func, "%p"),
+        LONGTAIL_LOGFIELD(prune_blocks_func, "%p"),
         LONGTAIL_LOGFIELD(get_stats_func, "%p"),
         LONGTAIL_LOGFIELD(flush_func, "%p")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_INFO)
@@ -657,6 +659,7 @@ struct Longtail_BlockStoreAPI* Longtail_MakeBlockStoreAPI(
     api->PreflightGet = preflight_get_func;
     api->GetStoredBlock = get_stored_block_func;
     api->GetExistingContent = get_existing_content_func;
+    api->PruneBlocks = prune_blocks_func;
     api->GetStats = get_stats_func;
     api->Flush = flush_func;
     return api;
@@ -666,6 +669,7 @@ int Longtail_BlockStore_PutStoredBlock(struct Longtail_BlockStoreAPI* block_stor
 int Longtail_BlockStore_PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, struct Longtail_AsyncPreflightStartedAPI* optional_async_complete_api) { return block_store_api->PreflightGet(block_store_api, chunk_count, chunk_hashes, optional_async_complete_api); }
 int Longtail_BlockStore_GetStoredBlock(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_hash, struct Longtail_AsyncGetStoredBlockAPI* async_complete_api) { return block_store_api->GetStoredBlock(block_store_api, block_hash, async_complete_api); }
 int Longtail_BlockStore_GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api) { return block_store_api->GetExistingContent(block_store_api, chunk_count, chunk_hashes, min_block_usage_percent, async_complete_api); }
+int Longtail_BlockStore_PruneBlocks(struct Longtail_BlockStoreAPI* block_store_api, uint32_t block_keep_count, const TLongtail_Hash* block_keep_hashes, struct Longtail_AsyncPruneBlocksAPI* async_complete_api) { return block_store_api->PruneBlocks(block_store_api, block_keep_count, block_keep_hashes, async_complete_api);}
 int Longtail_BlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats) { return block_store_api->GetStats(block_store_api, out_stats); }
 int Longtail_BlockStore_Flush(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_AsyncFlushAPI* async_complete_api) {return block_store_api->Flush(block_store_api, async_complete_api); }
 

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -3188,6 +3188,7 @@ int Longtail_ReadBlockIndex(
         storage_api->CloseFile(storage_api, f);
         return err;
     }
+    storage_api->CloseFile(storage_api, f);
     *out_block_index = block_index;
     return 0;
 }

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -602,6 +602,18 @@ struct Longtail_AsyncGetExistingContentAPI
     Longtail_AsyncGetExistingContent_OnCompleteFunc OnComplete;
 };
 
+////////////// Longtail_AsyncGetExistingContentAPI
+
+struct Longtail_AsyncPruneBlocksAPI;
+
+typedef void (*Longtail_AsyncPruneBlocks_OnCompleteFunc)(struct Longtail_AsyncPruneBlocksAPI* async_complete_api, uint32_t pruned_block_count, int err);
+
+struct Longtail_AsyncPruneBlocksAPI
+{
+    struct Longtail_API m_API;
+    Longtail_AsyncPruneBlocks_OnCompleteFunc OnComplete;
+};
+
 LONGTAIL_EXPORT uint64_t Longtail_GetAsyncGetExistingContentAPISize();
 
 LONGTAIL_EXPORT struct Longtail_AsyncGetExistingContentAPI* Longtail_MakeAsyncGetExistingContentAPI(
@@ -675,6 +687,10 @@ enum
     Longtail_BlockStoreAPI_StatU64_GetExistingContent_RetryCount,
     Longtail_BlockStoreAPI_StatU64_GetExistingContent_FailCount,
 
+    Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count,
+    Longtail_BlockStoreAPI_StatU64_PruneBlocks_RetryCount,
+    Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount,
+
     Longtail_BlockStoreAPI_StatU64_PreflightGet_Count,
     Longtail_BlockStoreAPI_StatU64_PreflightGet_RetryCount,
     Longtail_BlockStoreAPI_StatU64_PreflightGet_FailCount,
@@ -695,6 +711,7 @@ typedef int (*Longtail_BlockStore_PutStoredBlockFunc)(struct Longtail_BlockStore
 typedef int (*Longtail_BlockStore_PreflightGetFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint32_t block_count, const TLongtail_Hash* block_hashes, struct Longtail_AsyncPreflightStartedAPI* optional_async_complete_api);
 typedef int (*Longtail_BlockStore_GetStoredBlockFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_hash, struct Longtail_AsyncGetStoredBlockAPI* async_complete_api);
 typedef int (*Longtail_BlockStore_GetExistingContentFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent,  struct Longtail_AsyncGetExistingContentAPI* async_complete_api);
+typedef int (*Longtail_BlockStore_PruneBlocksFunc)(struct Longtail_BlockStoreAPI* block_store_api, uint32_t block_keep_count, const TLongtail_Hash* block_keep_hashes, struct Longtail_AsyncPruneBlocksAPI* async_complete_api);
 typedef int (*Longtail_BlockStore_GetStatsFunc)(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats);
 typedef int (*Longtail_BlockStore_FlushFunc)(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_AsyncFlushAPI* async_complete_api);
 
@@ -705,6 +722,7 @@ struct Longtail_BlockStoreAPI
     Longtail_BlockStore_PreflightGetFunc PreflightGet;
     Longtail_BlockStore_GetStoredBlockFunc GetStoredBlock;
     Longtail_BlockStore_GetExistingContentFunc GetExistingContent;
+    Longtail_BlockStore_PruneBlocksFunc PruneBlocks;
     Longtail_BlockStore_GetStatsFunc GetStats;
     Longtail_BlockStore_FlushFunc Flush;
 };
@@ -719,6 +737,7 @@ LONGTAIL_EXPORT struct Longtail_BlockStoreAPI* Longtail_MakeBlockStoreAPI(
     Longtail_BlockStore_PreflightGetFunc preflight_get_func,
     Longtail_BlockStore_GetStoredBlockFunc get_stored_block_func,
     Longtail_BlockStore_GetExistingContentFunc get_existing_content_func,
+    Longtail_BlockStore_PruneBlocksFunc prune_blocks_func,
     Longtail_BlockStore_GetStatsFunc get_stats_func,
     Longtail_BlockStore_FlushFunc flush_func);
 
@@ -726,6 +745,7 @@ LONGTAIL_EXPORT int Longtail_BlockStore_PutStoredBlock(struct Longtail_BlockStor
 LONGTAIL_EXPORT int Longtail_BlockStore_PreflightGet(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, struct Longtail_AsyncPreflightStartedAPI* optional_async_complete_api);
 LONGTAIL_EXPORT int Longtail_BlockStore_GetStoredBlock(struct Longtail_BlockStoreAPI* block_store_api, uint64_t block_hash, struct Longtail_AsyncGetStoredBlockAPI* async_complete_api);
 LONGTAIL_EXPORT int Longtail_BlockStore_GetExistingContent(struct Longtail_BlockStoreAPI* block_store_api, uint32_t chunk_count, const TLongtail_Hash* chunk_hashes, uint32_t min_block_usage_percent, struct Longtail_AsyncGetExistingContentAPI* async_complete_api);
+LONGTAIL_EXPORT int Longtail_BlockStore_PruneBlocks(struct Longtail_BlockStoreAPI* block_store_api, uint32_t block_keep_count, const TLongtail_Hash* block_keep_hashes,  struct Longtail_AsyncPruneBlocksAPI* async_complete_api);
 LONGTAIL_EXPORT int Longtail_BlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats);
 LONGTAIL_EXPORT int Longtail_BlockStore_Flush(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_AsyncFlushAPI* async_complete_api);
 

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -1501,6 +1501,12 @@ LONGTAIL_EXPORT int Longtail_GetExistingStoreIndex(
     uint32_t min_block_usage_percent,
     struct Longtail_StoreIndex** out_store_index);
 
+LONGTAIL_EXPORT int Longtail_PruneStoreIndex(
+    const struct Longtail_StoreIndex* source_store_index,
+    uint32_t keep_block_count,
+    const TLongtail_Hash* keep_block_hashes,
+    struct Longtail_StoreIndex** out_store_index);
+
 /*! @brief Validate that store_index contains all of version_index.
  *
  * Validates that all chunks required for @p version_index are present in @p store_index

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -602,7 +602,16 @@ struct Longtail_AsyncGetExistingContentAPI
     Longtail_AsyncGetExistingContent_OnCompleteFunc OnComplete;
 };
 
-////////////// Longtail_AsyncGetExistingContentAPI
+LONGTAIL_EXPORT uint64_t Longtail_GetAsyncGetExistingContentAPISize();
+
+LONGTAIL_EXPORT struct Longtail_AsyncGetExistingContentAPI* Longtail_MakeAsyncGetExistingContentAPI(
+    void* mem,
+    Longtail_DisposeFunc dispose_func,
+    Longtail_AsyncGetExistingContent_OnCompleteFunc on_complete_func);
+
+LONGTAIL_EXPORT void Longtail_AsyncGetExistingContent_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_StoreIndex* store_index, int err);
+
+////////////// Longtail_AsyncPruneBlocksAPI
 
 struct Longtail_AsyncPruneBlocksAPI;
 
@@ -614,14 +623,14 @@ struct Longtail_AsyncPruneBlocksAPI
     Longtail_AsyncPruneBlocks_OnCompleteFunc OnComplete;
 };
 
-LONGTAIL_EXPORT uint64_t Longtail_GetAsyncGetExistingContentAPISize();
+LONGTAIL_EXPORT uint64_t Longtail_GetAsyncPruneBlocksAPISize();
 
-LONGTAIL_EXPORT struct Longtail_AsyncGetExistingContentAPI* Longtail_MakeAsyncGetExistingContentAPI(
+LONGTAIL_EXPORT struct Longtail_AsyncPruneBlocksAPI* Longtail_MakeAsyncPruneBlocksAPI(
     void* mem,
     Longtail_DisposeFunc dispose_func,
-    Longtail_AsyncGetExistingContent_OnCompleteFunc on_complete_func);
+    Longtail_AsyncPruneBlocks_OnCompleteFunc on_complete_func);
 
-LONGTAIL_EXPORT void Longtail_AsyncGetExistingContent_OnComplete(struct Longtail_AsyncGetExistingContentAPI* async_complete_api, struct Longtail_StoreIndex* store_index, int err);
+LONGTAIL_EXPORT void Longtail_AsyncPruneBlocks_OnComplete(struct Longtail_AsyncPruneBlocksAPI* async_complete_api, uint32_t pruned_block_count, int err);
 
 ////////////// Longtail_AsyncPreflightStartedAPI
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -6728,6 +6728,7 @@ TEST(Longtail, Longtail_PruneStoreIndex)
     Longtail_Free(block2_kept_store_index);
     Longtail_Free(block1_kept_store_index);
     Longtail_Free(store_index);
+    Longtail_Free(block_index3);
     Longtail_Free(block_index2);
     Longtail_Free(block_index1);
     SAFE_DISPOSE_API(hash_api);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -6783,6 +6783,7 @@ TEST(Longtail, Longtail_PruneFSBlockStore)
     ASSERT_EQ(0, block_store_api->PruneBlocks(block_store_api, 2, block1and3hash, &pruneCB.m_API));
     pruneCB.Wait();
     ASSERT_EQ(0, pruneCB.m_Err);
+    ASSERT_EQ(1, pruneCB.m_PruneCount);
 
     {
         struct TestAsyncGetBlockComplete getCB0;


### PR DESCRIPTION
- **CHANGED API** `Longtail_BlockStoreAPI` has new function `PruneBlocks`
- **CHANGED API** `Longtail_BlockStore_Stats` has three new fields `Longtail_BlockStoreAPI_StatU64_PruneBlocks_Count`, `Longtail_BlockStoreAPI_StatU64_PruneBlocks_RetryCount` and `Longtail_BlockStoreAPI_StatU64_PruneBlocks_FailCount`
- **ADDED** `Longtail_PruneStoreIndex` function added to remove blocks from a store index