### PR TITLE
Issues/160 blocking on upsync

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -133,7 +133,9 @@ jobs:
         release_name: Release ${{ env.RELEASE_VERSION }}
         body: |
           # Changes in this Release
-          - **FIX** Fix ZSTD_DISABLE_ASM link errors
+          - **CHANGED API** JobAPI now has `GetMaxBatchCount` function for querying max queued job count
+          - **FIX** Fix issue 160 - `CreateVersionIndex` and `WriteContent` getting blocked when > 131072 files
+          - **FIX** Long paths in Windows
         draft: false
         prerelease: false
         files: "*-x64.zip"

--- a/lib/longtail_platform.c
+++ b/lib/longtail_platform.c
@@ -124,9 +124,15 @@ static int Win32ErrorToErrno(DWORD err)
 
 static const char* MakeLongPath(const char* path)
 {
+    if (path[0] && (path[1] != ':'))
+    {
+        // Don't add long path prefix if we don't specify a drive
+        return path;
+    }
     size_t path_len = strlen(path);
     if (path_len < MAX_PATH)
     {
+        // Don't add long path prefix if the path isn't that long
         return path;
     }
     static const char* LongPathPrefix = "\\\\?\\";

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -413,7 +413,8 @@ struct Longtail_JobAPI* Longtail_MakeJobAPI(
     Longtail_Job_AddDependeciesFunc add_dependecies_func,
     Longtail_Job_ReadyJobsFunc ready_jobs_func,
     Longtail_Job_WaitForAllJobsFunc wait_for_all_jobs_func,
-    Longtail_Job_ResumeJobFunc resume_job_func)
+    Longtail_Job_ResumeJobFunc resume_job_func,
+    Longtail_Job_GetMaxBatchCountFunc get_max_batch_count_func)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(mem, "%p"),
@@ -424,7 +425,8 @@ struct Longtail_JobAPI* Longtail_MakeJobAPI(
         LONGTAIL_LOGFIELD(add_dependecies_func, "%p"),
         LONGTAIL_LOGFIELD(ready_jobs_func, "%p"),
         LONGTAIL_LOGFIELD(wait_for_all_jobs_func, "%p"),
-        LONGTAIL_LOGFIELD(resume_job_func, "%p")
+        LONGTAIL_LOGFIELD(resume_job_func, "%p"),
+        LONGTAIL_LOGFIELD(get_max_batch_count_func, "%p")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_INFO)
 
     LONGTAIL_VALIDATE_INPUT(ctx, mem != 0, return 0)
@@ -437,6 +439,7 @@ struct Longtail_JobAPI* Longtail_MakeJobAPI(
     api->ReadyJobs = ready_jobs_func;
     api->WaitForAllJobs = wait_for_all_jobs_func;
     api->ResumeJob = resume_job_func;
+    api->GetMaxBatchCountFunc = get_max_batch_count_func;
     return api;
 }
 
@@ -447,6 +450,7 @@ int Longtail_Job_AddDependecies(struct Longtail_JobAPI* job_api, uint32_t job_co
 int Longtail_Job_ReadyJobs(struct Longtail_JobAPI* job_api, uint32_t job_count, Longtail_JobAPI_Jobs jobs) { return job_api->ReadyJobs(job_api, job_count, jobs); }
 int Longtail_Job_WaitForAllJobs(struct Longtail_JobAPI* job_api, Longtail_JobAPI_Group job_group, struct Longtail_ProgressAPI* progressAPI, struct Longtail_CancelAPI* optional_cancel_api, Longtail_CancelAPI_HCancelToken optional_cancel_token) { return job_api->WaitForAllJobs(job_api, job_group, progressAPI, optional_cancel_api, optional_cancel_token); }
 int Longtail_Job_ResumeJob(struct Longtail_JobAPI* job_api, uint32_t job_id) { return job_api->ResumeJob(job_api, job_id); }
+int Longtail_Job_GetMaxBatchCount(struct Longtail_JobAPI* job_api, uint32_t* out_max_job_batch_count, uint32_t* out_max_dependency_batch_count) { return job_api->GetMaxBatchCountFunc(job_api, out_max_job_batch_count, out_max_dependency_batch_count); }
 
 ////////////// ChunkerAPI
 

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -470,6 +470,7 @@ typedef int (*Longtail_Job_AddDependeciesFunc)(struct Longtail_JobAPI* job_api, 
 typedef int (*Longtail_Job_ReadyJobsFunc)(struct Longtail_JobAPI* job_api, uint32_t job_count, Longtail_JobAPI_Jobs jobs);
 typedef int (*Longtail_Job_WaitForAllJobsFunc)(struct Longtail_JobAPI* job_api, Longtail_JobAPI_Group job_group, struct Longtail_ProgressAPI* progressAPI, struct Longtail_CancelAPI* optional_cancel_api, Longtail_CancelAPI_HCancelToken optional_cancel_token);
 typedef int (*Longtail_Job_ResumeJobFunc)(struct Longtail_JobAPI* job_api, uint32_t job_id);
+typedef int (*Longtail_Job_GetMaxBatchCountFunc)(struct Longtail_JobAPI* job_api, uint32_t* out_max_job_batch_count, uint32_t* out_max_dependency_batch_count);
 
 struct Longtail_JobAPI
 {
@@ -481,6 +482,7 @@ struct Longtail_JobAPI
     Longtail_Job_ReadyJobsFunc ReadyJobs;
     Longtail_Job_WaitForAllJobsFunc WaitForAllJobs;
     Longtail_Job_ResumeJobFunc ResumeJob;
+    Longtail_Job_GetMaxBatchCountFunc GetMaxBatchCountFunc;
 };
 
 LONGTAIL_EXPORT uint64_t Longtail_GetJobAPISize();
@@ -494,7 +496,8 @@ struct Longtail_JobAPI* Longtail_MakeJobAPI(
     Longtail_Job_AddDependeciesFunc add_dependecies_func,
     Longtail_Job_ReadyJobsFunc ready_jobs_func,
     Longtail_Job_WaitForAllJobsFunc wait_for_all_jobs_func,
-    Longtail_Job_ResumeJobFunc resume_job_func);
+    Longtail_Job_ResumeJobFunc resume_job_func,
+    Longtail_Job_GetMaxBatchCountFunc get_max_batch_count_func);
 
 LONGTAIL_EXPORT uint32_t Longtail_Job_GetWorkerCount(struct Longtail_JobAPI* job_api);
 LONGTAIL_EXPORT int Longtail_Job_ReserveJobs(struct Longtail_JobAPI* job_api, uint32_t job_count, Longtail_JobAPI_Group* out_job_group);
@@ -503,6 +506,7 @@ LONGTAIL_EXPORT int Longtail_Job_AddDependecies(struct Longtail_JobAPI* job_api,
 LONGTAIL_EXPORT int Longtail_Job_ReadyJobs(struct Longtail_JobAPI* job_api, uint32_t job_count, Longtail_JobAPI_Jobs jobs);
 LONGTAIL_EXPORT int Longtail_Job_WaitForAllJobs(struct Longtail_JobAPI* job_api, Longtail_JobAPI_Group job_group, struct Longtail_ProgressAPI* progressAPI, struct Longtail_CancelAPI* optional_cancel_api, Longtail_CancelAPI_HCancelToken optional_cancel_token);
 LONGTAIL_EXPORT int Longtail_Job_ResumeJob(struct Longtail_JobAPI* job_api, uint32_t job_id);
+LONGTAIL_EXPORT int Longtail_Job_GetMaxBatchCount(struct Longtail_JobAPI* job_api, uint32_t* out_max_job_batch_count, uint32_t* out_max_dependency_batch_count);
 
 ////////////// Longtail_ChunkerAPI
 


### PR DESCRIPTION
- **CHANGED API** JobAPI now has `GetMaxBatchCount` function for querying max queued job count
- **FIX** Fix issue 160 - `CreateVersionIndex` and `WriteContent` getting blocked when > 131072 files
- **FIX** Long paths in Windows
