### PR TITLE
fix network drives

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -134,7 +134,7 @@ jobs:
         body: |
           # Changes in this Release
           - **CHANGED API** `Longtail_StorageAPI.CreateDirectory` is now expected to create the full path hierarchy
-          - **FIX** Add retry when opening files and creating directories due to network drives are sometimes slow in picking up create directories
+          - **FIX** Add retry when opening files and creating directories on Win32 platform due to network drives are sometimes slow in picking up create directories
         draft: false
         prerelease: false
         files: "*-x64.zip"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -133,19 +133,8 @@ jobs:
         release_name: Release ${{ env.RELEASE_VERSION }}
         body: |
           # Changes in this Release
-          - **CHANGED API** `Longtail_StorageAPI` now has `MapFile` and `UnMapFile` to do memory mapping of files when reading, return ENOTSUP in implementation to enable regular I/O fallback.
-          - **CHANGED API** `Longtail_CreateArchiveBlockStore` now takes flag to enable or disable memory mapped reading of blocks
-          - **CHANGED API** `Longtail_CreateVersionIndex` now takes flag to enable or disable memory mapped reading of files
-          - **CHANGED API** `Longtail_ChunkerAPI` now has `NextChunkFromBuffer` method used when enabling memory mapping during `Longtail_CreateVersionIndex`
-          - **CHANGED API** `Longtail_CreateFSBlockStoreAPI` now takes flag to enable or disable memory mapped reading of block files
-          - **FIX** Sort of write jobs for assets spanning multiple blocks to increase hit rate in LRU (perf improvement)
-          - **FIX** Remove redundant check if directory exists when getting directory name (perf improvement)
-          - **FIX** Use SOA for asset part lookup (perf improvement)
-          - **FIX** Fix memory leak when retain permissions was set to off
-          - **FIX** Faster EnsureParentPathExists (perf improvement)
-          - **FIX** ArchiveBlockStore no longer keeps spin lock when reading or writing blocks (perf improvement)
-          - **UPDATE** zstdlib updated to 1.5.2
-          - **UPDATE** Blake3 to 1.3.1
+          - **CHANGED API** `Longtail_StorageAPI.CreateDirectory` is now expected to create the full path hierarchy
+          - **FIX** Add retry when opening files and creating directories due to network drives are sometimes slow in picking up create directories
         draft: false
         prerelease: false
         files: "*-x64.zip"

--- a/lib/filestorage/longtail_filestorage.c
+++ b/lib/filestorage/longtail_filestorage.c
@@ -296,7 +296,7 @@ static int FSStorageAPI_CreateDir(struct Longtail_StorageAPI* storage_api, const
     LONGTAIL_VALIDATE_INPUT(ctx, storage_api != 0, return EINVAL);
     LONGTAIL_VALIDATE_INPUT(ctx, path != 0, return EINVAL);
     int err = Longtail_CreateDirectory(path);
-    if (err)
+    if (err && err != EEXIST)
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_INFO, "Longtail_CreateDirectory() failed with %d", err)
         return err;

--- a/lib/longtail_platform.c
+++ b/lib/longtail_platform.c
@@ -1672,6 +1672,29 @@ int Longtail_CreateDirectory(const char* path)
         return 0;
     }
     int e = errno;
+    if (e == ENOENT)
+    {
+        // Try to create parent folder
+        const char* delim_path = strrchr(path, '/');
+        if (delim_path == 0)
+        {
+            return e;
+        }
+        char* parent_path = Longtail_Strdup(path);
+        parent_path[delim_path - path] = '\0';
+        int parent_err = Longtail_CreateDirectory(parent_path);
+        Longtail_Free(parent_path);
+        if (parent_err != 0 && parent_err != EEXIST)
+        {
+            return e;
+        }
+        err = mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+        if (err == 0)
+        {
+            return 0;
+        }
+        e = errno;
+    }
     return e;
 }
 

--- a/lib/longtail_platform.c
+++ b/lib/longtail_platform.c
@@ -451,9 +451,9 @@ static DWORD NativeCreateDirectory(wchar_t* long_path)
                 return last_error;
             }
             long_path[delim_pos] = '\0';
-            last_error = NativeCreateDirectory(long_path);
+            DWORD parent_error = NativeCreateDirectory(long_path);
             long_path[delim_pos] = '\\';
-            switch (last_error)
+            switch (parent_error)
             {
                 case ERROR_SUCCESS:
                 case ERROR_FILE_EXISTS:

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -1148,14 +1148,10 @@ int Longtail_GetPathHash(struct Longtail_HashAPI* hash_api, const char* path, TL
 
 int EnsureParentPathExists(struct Longtail_StorageAPI* storage_api, const char* path)
 {
-#if defined(LONGTAIL_ASSERTS)
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(storage_api, "%p"),
         LONGTAIL_LOGFIELD(path, "%s")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_OFF)
-#else
-    struct Longtail_LogContextFmt_Private* ctx = 0;
-#endif // defined(LONGTAIL_ASSERTS)
 
     LONGTAIL_FATAL_ASSERT(ctx, storage_api != 0, return EINVAL)
     LONGTAIL_FATAL_ASSERT(ctx, path != 0, return EINVAL)
@@ -1167,23 +1163,10 @@ int EnsureParentPathExists(struct Longtail_StorageAPI* storage_api, const char* 
     }
 
     int err = storage_api->CreateDir(storage_api, parent_path);
+    Longtail_Free(parent_path);
     if (err == 0 || err == EEXIST) {
-        Longtail_Free(parent_path);
         return 0;
     }
-    err = EnsureParentPathExists(storage_api, parent_path);
-    if (err != 0)
-    {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "EnsureParentPathExists() failed with %d", err)
-        Longtail_Free(parent_path);
-        return err;
-    }
-    err = storage_api->CreateDir(storage_api, parent_path);
-    if (err == EEXIST)
-    {
-        err = 0;
-    }
-    Longtail_Free(parent_path);
     return err;
 }
 


### PR DESCRIPTION
- **CHANGED API** `Longtail_StorageAPI.CreateDirectory` is now expected to create the full path hierarchy
- - **FIX** Add retry when opening files and creating directories on Win32 platform due to network drives are sometimes slow in picking up create directories