### PR TITLE
Feature/add zstd compression options

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -134,7 +134,10 @@ jobs:
         body: |
           # Changes in this Release
           - **CHANGED API** `Longtail_StorageAPI.CreateDirectory` is now expected to create the full path hierarchy
+          - **CHANGED API** `Longtail_CreateDefaultCompressionRegistry` is now takes callback functions to create compression apis, this makes it possible to add new compression settings for a compression type without breaking older versions
           - **FIX** Add retry when opening files and creating directories on Win32 platform due to network drives are sometimes slow in picking up create directories
+          - **NEW API** `Longtail_GetZStdHighQuality`, `Longtail_GetZStdLowQuality` added
+          - **NEW API** `Longtail_CompressionRegistry_CreateForBrotli`, `Longtail_CompressionRegistry_CreateForLZ4`, `Longtail_CompressionRegistry_CreateForZstd`
         draft: false
         prerelease: false
         files: "*-x64.zip"

--- a/cmd/main.c
+++ b/cmd/main.c
@@ -212,6 +212,14 @@ uint32_t ParseCompressionType(const char* compression_algorithm) {
     {
         return Longtail_GetZStdMaxQuality();
     }
+    if (strcmp("zstd_high", compression_algorithm) == 0)
+    {
+        return Longtail_GetZStdHighQuality();
+    }
+    if (strcmp("zstd_low", compression_algorithm) == 0)
+    {
+        return Longtail_GetZStdLowQuality();
+    }
     return 0xffffffff;
 }
 

--- a/lib/brotli/longtail_brotli.c
+++ b/lib/brotli/longtail_brotli.c
@@ -21,12 +21,13 @@ static struct BrotliSettings LONGTAIL_BROTLI_TEXT_MIN_QUALITY_SETTINGS        = 
 static struct BrotliSettings LONGTAIL_BROTLI_TEXT_DEFAULT_QUALITY_SETTINGS    = {BROTLI_MODE_TEXT,    BROTLI_DEFAULT_WINDOW,  BROTLI_DEFAULT_QUALITY};
 static struct BrotliSettings LONGTAIL_BROTLI_TEXT_MAX_QUALITY_SETTINGS        = {BROTLI_MODE_TEXT,    BROTLI_MAX_WINDOW_BITS, BROTLI_MAX_QUALITY};
 
-#define LONGTAIL_BROTLI_GENERIC_MIN_QUALITY_TYPE     ((((uint32_t)'b') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'l') << 8) + ((uint32_t)'0'))
-#define LONGTAIL_BROTLI_GENERIC_DEFAULT_QUALITY_TYPE ((((uint32_t)'b') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'l') << 8) + ((uint32_t)'1'))
-#define LONGTAIL_BROTLI_GENERIC_MAX_QUALITY_TYPE     ((((uint32_t)'b') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'l') << 8) + ((uint32_t)'2'))
-#define LONGTAIL_BROTLI_TEXT_MIN_QUALITY_TYPE        ((((uint32_t)'b') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'l') << 8) + ((uint32_t)'a'))
-#define LONGTAIL_BROTLI_TEXT_DEFAULT_QUALITY_TYPE    ((((uint32_t)'b') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'l') << 8) + ((uint32_t)'b'))
-#define LONGTAIL_BROTLI_TEXT_MAX_QUALITY_TYPE        ((((uint32_t)'b') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'l') << 8) + ((uint32_t)'c'))
+#define LONGTAIL_BROTLI_COMPRESSION_TYPE             ((((uint32_t)'b') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'l') << 8))
+#define LONGTAIL_BROTLI_GENERIC_MIN_QUALITY_TYPE     (LONGTAIL_BROTLI_COMPRESSION_TYPE + ((uint32_t)'0'))
+#define LONGTAIL_BROTLI_GENERIC_DEFAULT_QUALITY_TYPE (LONGTAIL_BROTLI_COMPRESSION_TYPE + ((uint32_t)'1'))
+#define LONGTAIL_BROTLI_GENERIC_MAX_QUALITY_TYPE     (LONGTAIL_BROTLI_COMPRESSION_TYPE + ((uint32_t)'2'))
+#define LONGTAIL_BROTLI_TEXT_MIN_QUALITY_TYPE        (LONGTAIL_BROTLI_COMPRESSION_TYPE + ((uint32_t)'a'))
+#define LONGTAIL_BROTLI_TEXT_DEFAULT_QUALITY_TYPE    (LONGTAIL_BROTLI_COMPRESSION_TYPE + ((uint32_t)'b'))
+#define LONGTAIL_BROTLI_TEXT_MAX_QUALITY_TYPE        (LONGTAIL_BROTLI_COMPRESSION_TYPE + ((uint32_t)'c'))
 
 uint32_t Longtail_GetBrotliGenericMinQuality() { return LONGTAIL_BROTLI_GENERIC_MIN_QUALITY_TYPE; }
 uint32_t Longtail_GetBrotliGenericDefaultQuality() { return LONGTAIL_BROTLI_GENERIC_DEFAULT_QUALITY_TYPE; }
@@ -34,6 +35,19 @@ uint32_t Longtail_GetBrotliGenericMaxQuality() { return LONGTAIL_BROTLI_GENERIC_
 uint32_t Longtail_GetBrotliTextMinQuality() { return LONGTAIL_BROTLI_TEXT_MIN_QUALITY_TYPE; }
 uint32_t Longtail_GetBrotliTextDefaultQuality() { return LONGTAIL_BROTLI_TEXT_DEFAULT_QUALITY_TYPE; }
 uint32_t Longtail_GetBrotliTextMaxQuality() { return LONGTAIL_BROTLI_TEXT_MAX_QUALITY_TYPE; }
+
+struct Longtail_CompressionAPI* Longtail_CompressionRegistry_CreateForBrotli(uint32_t compression_type, uint32_t* out_settings)
+{
+    if ((compression_type & 0xffffff00) != LONGTAIL_BROTLI_COMPRESSION_TYPE)
+    {
+        return 0;
+    }
+    if (out_settings)
+    {
+        *out_settings = compression_type;
+    }
+    return Longtail_CreateBrotliCompressionAPI();
+}
 
 static struct BrotliSettings* SettingsIDToCompressionSetting(uint32_t settings_id)
 {

--- a/lib/brotli/longtail_brotli.h
+++ b/lib/brotli/longtail_brotli.h
@@ -14,6 +14,7 @@ LONGTAIL_EXPORT extern uint32_t Longtail_GetBrotliGenericMaxQuality();
 LONGTAIL_EXPORT extern uint32_t Longtail_GetBrotliTextMinQuality();
 LONGTAIL_EXPORT extern uint32_t Longtail_GetBrotliTextDefaultQuality();
 LONGTAIL_EXPORT extern uint32_t Longtail_GetBrotliTextMaxQuality();
+LONGTAIL_EXPORT extern struct Longtail_CompressionAPI* Longtail_CompressionRegistry_CreateForBrotli(uint32_t compression_type, uint32_t* out_settings);
 
 #ifdef __cplusplus
 }

--- a/lib/compressblockstore/longtail_compressblockstore.c
+++ b/lib/compressblockstore/longtail_compressblockstore.c
@@ -89,7 +89,7 @@ static int CompressBlock(
         return 0;
     }
     struct Longtail_CompressionAPI* compression_api;
-    uint32_t compression_settings;
+        uint32_t compression_settings;
     int err = compression_registry->GetCompressionAPI(
         compression_registry,
         compressionType,

--- a/lib/compressionregistry/longtail_compression_registry.c
+++ b/lib/compressionregistry/longtail_compression_registry.c
@@ -36,6 +36,12 @@ static void DefaultCompressionRegistry_Dispose(struct Longtail_API* api)
 
     LONGTAIL_VALIDATE_INPUT(ctx, api, return);
     struct Default_CompressionRegistry* default_compression_registry = (struct Default_CompressionRegistry*)api;
+    intptr_t api_count = hmlen(default_compression_registry->m_CompressionAPIs);
+    for (intptr_t i = 0; i < api_count; ++i)
+    {
+        struct Longtail_API* dispose_api = &default_compression_registry->m_CompressionAPIs[i].value.api->m_API;
+        dispose_api->Dispose(dispose_api);
+    }
     hmfree(default_compression_registry->m_CompressionAPIs);
     Longtail_DeleteSpinLock(default_compression_registry->m_SpinLock);
     Longtail_Free(default_compression_registry);

--- a/lib/compressionregistry/longtail_compression_registry.h
+++ b/lib/compressionregistry/longtail_compression_registry.h
@@ -6,11 +6,11 @@
 extern "C" {
 #endif
 
+typedef struct Longtail_CompressionAPI* (*Longtail_CompressionRegistry_CreateForTypeFunc)(uint32_t compression_type, uint32_t* out_settings);
+
 LONGTAIL_EXPORT extern struct Longtail_CompressionRegistryAPI* Longtail_CreateDefaultCompressionRegistry(
-        uint32_t compression_type_count,
-        const uint32_t* compression_types,
-        const struct Longtail_CompressionAPI** compression_apis,
-        const uint32_t* compression_setting_ids);
+        uint32_t compression_api_count,
+        const Longtail_CompressionRegistry_CreateForTypeFunc* create_api_funcs);
 
 #ifdef __cplusplus
 }

--- a/lib/compressionregistry/longtail_full_compression_registry.c
+++ b/lib/compressionregistry/longtail_full_compression_registry.c
@@ -29,7 +29,7 @@ struct Longtail_CompressionRegistryAPI* Longtail_CreateFullCompressionRegistry()
         return 0;
     }
 
-    uint32_t compression_types[13] = {
+    uint32_t compression_types[12] = {
         Longtail_GetBrotliGenericMinQuality(),
         Longtail_GetBrotliGenericDefaultQuality(),
         Longtail_GetBrotliGenericMaxQuality(),
@@ -41,8 +41,10 @@ struct Longtail_CompressionRegistryAPI* Longtail_CreateFullCompressionRegistry()
 
         Longtail_GetZStdMinQuality(),
         Longtail_GetZStdDefaultQuality(),
-        Longtail_GetZStdMaxQuality()};
-    struct Longtail_CompressionAPI* compression_apis[10] = {
+        Longtail_GetZStdMaxQuality(),
+        Longtail_GetZStdHighQuality(),
+        Longtail_GetZStdLowQuality()};
+    struct Longtail_CompressionAPI* compression_apis[12] = {
         brotli_compression,
         brotli_compression,
         brotli_compression,
@@ -52,8 +54,10 @@ struct Longtail_CompressionRegistryAPI* Longtail_CreateFullCompressionRegistry()
         lz4_compression,
         zstd_compression,
         zstd_compression,
+        zstd_compression,
+        zstd_compression,
         zstd_compression};
-    uint32_t compression_settings[10] = {
+    uint32_t compression_settings[12] = {
         Longtail_GetBrotliGenericMinQuality(),
         Longtail_GetBrotliGenericDefaultQuality(),
         Longtail_GetBrotliGenericMaxQuality(),
@@ -63,10 +67,12 @@ struct Longtail_CompressionRegistryAPI* Longtail_CreateFullCompressionRegistry()
         Longtail_GetLZ4DefaultQuality(),
         Longtail_GetZStdMinQuality(),
         Longtail_GetZStdDefaultQuality(),
-        Longtail_GetZStdMaxQuality()};
+        Longtail_GetZStdMaxQuality(),
+        Longtail_GetZStdHighQuality(),
+        Longtail_GetZStdLowQuality()};
 
     struct Longtail_CompressionRegistryAPI* registry = Longtail_CreateDefaultCompressionRegistry(
-        10,
+        12,
         (const uint32_t*)compression_types,
         (const struct Longtail_CompressionAPI **)compression_apis,
         compression_settings);

--- a/lib/compressionregistry/longtail_full_compression_registry.c
+++ b/lib/compressionregistry/longtail_full_compression_registry.c
@@ -8,80 +8,12 @@
 
 struct Longtail_CompressionRegistryAPI* Longtail_CreateFullCompressionRegistry()
 {
-    struct Longtail_CompressionAPI* lz4_compression = Longtail_CreateLZ4CompressionAPI();
-    if (lz4_compression == 0)
-    {
-        return 0;
-    }
+    Longtail_CompressionRegistry_CreateForTypeFunc compression_create_api_funcs[3] = {
+        Longtail_CompressionRegistry_CreateForBrotli,
+        Longtail_CompressionRegistry_CreateForLZ4,
+        Longtail_CompressionRegistry_CreateForZstd};
 
-    struct Longtail_CompressionAPI* brotli_compression = Longtail_CreateBrotliCompressionAPI();
-    if (brotli_compression == 0)
-    {
-        SAFE_DISPOSE_API(lz4_compression);
-        return 0;
-    }
-
-    struct Longtail_CompressionAPI* zstd_compression = Longtail_CreateZStdCompressionAPI();
-    if (zstd_compression == 0)
-    {
-        SAFE_DISPOSE_API(lz4_compression);
-        SAFE_DISPOSE_API(brotli_compression);
-        return 0;
-    }
-
-    uint32_t compression_types[12] = {
-        Longtail_GetBrotliGenericMinQuality(),
-        Longtail_GetBrotliGenericDefaultQuality(),
-        Longtail_GetBrotliGenericMaxQuality(),
-        Longtail_GetBrotliTextMinQuality(),
-        Longtail_GetBrotliTextDefaultQuality(),
-        Longtail_GetBrotliTextMaxQuality(),
-
-        Longtail_GetLZ4DefaultQuality(),
-
-        Longtail_GetZStdMinQuality(),
-        Longtail_GetZStdDefaultQuality(),
-        Longtail_GetZStdMaxQuality(),
-        Longtail_GetZStdHighQuality(),
-        Longtail_GetZStdLowQuality()};
-    struct Longtail_CompressionAPI* compression_apis[12] = {
-        brotli_compression,
-        brotli_compression,
-        brotli_compression,
-        brotli_compression,
-        brotli_compression,
-        brotli_compression,
-        lz4_compression,
-        zstd_compression,
-        zstd_compression,
-        zstd_compression,
-        zstd_compression,
-        zstd_compression};
-    uint32_t compression_settings[12] = {
-        Longtail_GetBrotliGenericMinQuality(),
-        Longtail_GetBrotliGenericDefaultQuality(),
-        Longtail_GetBrotliGenericMaxQuality(),
-        Longtail_GetBrotliTextMinQuality(),
-        Longtail_GetBrotliTextDefaultQuality(),
-        Longtail_GetBrotliTextMaxQuality(),
-        Longtail_GetLZ4DefaultQuality(),
-        Longtail_GetZStdMinQuality(),
-        Longtail_GetZStdDefaultQuality(),
-        Longtail_GetZStdMaxQuality(),
-        Longtail_GetZStdHighQuality(),
-        Longtail_GetZStdLowQuality()};
-
-    struct Longtail_CompressionRegistryAPI* registry = Longtail_CreateDefaultCompressionRegistry(
-        12,
-        (const uint32_t*)compression_types,
-        (const struct Longtail_CompressionAPI **)compression_apis,
-        compression_settings);
-    if (registry == 0)
-    {
-        SAFE_DISPOSE_API(lz4_compression);
-        SAFE_DISPOSE_API(brotli_compression);
-        SAFE_DISPOSE_API(zstd_compression);
-        return 0;
-    }
-    return registry;
+    return Longtail_CreateDefaultCompressionRegistry(
+        3,
+        (const Longtail_CompressionRegistry_CreateForTypeFunc*)compression_create_api_funcs);
 }

--- a/lib/compressionregistry/longtail_zstd_compression_registry.c
+++ b/lib/compressionregistry/longtail_zstd_compression_registry.c
@@ -6,38 +6,10 @@
 
 struct Longtail_CompressionRegistryAPI* Longtail_CreateZStdCompressionRegistry()
 {
-    struct Longtail_CompressionAPI* zstd_compression = Longtail_CreateZStdCompressionAPI();
-    if (zstd_compression == 0)
-    {
-        return 0;
-    }
+    Longtail_CompressionRegistry_CreateForTypeFunc compression_create_api_funcs[1] = {
+        Longtail_CompressionRegistry_CreateForZstd};
 
-    uint32_t compression_types[5] = {
-        Longtail_GetZStdMinQuality(),
-        Longtail_GetZStdDefaultQuality(),
-        Longtail_GetZStdMaxQuality(),
-        Longtail_GetZStdHighQuality(),
-        Longtail_GetZStdLowQuality()};
-    struct Longtail_CompressionAPI* compression_apis[5] = {
-        zstd_compression,
-        zstd_compression,
-        zstd_compression};
-    uint32_t compression_settings[5] = {
-        Longtail_GetZStdMinQuality(),
-        Longtail_GetZStdDefaultQuality(),
-        Longtail_GetZStdMaxQuality(),
-        Longtail_GetZStdHighQuality(),
-        Longtail_GetZStdLowQuality()};
-
-    struct Longtail_CompressionRegistryAPI* registry = Longtail_CreateDefaultCompressionRegistry(
-        5,
-        (const uint32_t*)compression_types,
-        (const struct Longtail_CompressionAPI **)compression_apis,
-        compression_settings);
-    if (registry == 0)
-    {
-        SAFE_DISPOSE_API(zstd_compression);
-        return 0;
-    }
-    return registry;
+    return Longtail_CreateDefaultCompressionRegistry(
+        1,
+        (const Longtail_CompressionRegistry_CreateForTypeFunc*)compression_create_api_funcs);
 }

--- a/lib/compressionregistry/longtail_zstd_compression_registry.c
+++ b/lib/compressionregistry/longtail_zstd_compression_registry.c
@@ -12,21 +12,25 @@ struct Longtail_CompressionRegistryAPI* Longtail_CreateZStdCompressionRegistry()
         return 0;
     }
 
-    uint32_t compression_types[3] = {
+    uint32_t compression_types[5] = {
         Longtail_GetZStdMinQuality(),
         Longtail_GetZStdDefaultQuality(),
-        Longtail_GetZStdMaxQuality()};
-    struct Longtail_CompressionAPI* compression_apis[3] = {
+        Longtail_GetZStdMaxQuality(),
+        Longtail_GetZStdHighQuality(),
+        Longtail_GetZStdLowQuality()};
+    struct Longtail_CompressionAPI* compression_apis[5] = {
         zstd_compression,
         zstd_compression,
         zstd_compression};
-    uint32_t compression_settings[3] = {
+    uint32_t compression_settings[5] = {
         Longtail_GetZStdMinQuality(),
         Longtail_GetZStdDefaultQuality(),
-        Longtail_GetZStdMaxQuality()};
+        Longtail_GetZStdMaxQuality(),
+        Longtail_GetZStdHighQuality(),
+        Longtail_GetZStdLowQuality()};
 
     struct Longtail_CompressionRegistryAPI* registry = Longtail_CreateDefaultCompressionRegistry(
-        3,
+        5,
         (const uint32_t*)compression_types,
         (const struct Longtail_CompressionAPI **)compression_apis,
         compression_settings);

--- a/lib/lz4/longtail_lz4.c
+++ b/lib/lz4/longtail_lz4.c
@@ -9,6 +9,19 @@ static int LZ4CompressionAPI_DefaultCompressionSetting   = 1;
 
 #define LONGTAIL_LZ4_DEFAULT_COMPRESSION_TYPE ((((uint32_t)'l') << 24) + (((uint32_t)'z') << 16) + (((uint32_t)'4') << 8) + ((uint32_t)'2'))
 
+struct Longtail_CompressionAPI* Longtail_CompressionRegistry_CreateForLZ4(uint32_t compression_type, uint32_t* out_settings)
+{
+    if (compression_type != LONGTAIL_LZ4_DEFAULT_COMPRESSION_TYPE)
+    {
+        return 0;
+    }
+    if (out_settings)
+    {
+        *out_settings = compression_type;
+    }
+    return Longtail_CreateLZ4CompressionAPI();
+}
+
 uint32_t Longtail_GetLZ4DefaultQuality() { return LONGTAIL_LZ4_DEFAULT_COMPRESSION_TYPE; }
 
 static int SettingsIDToCompressionSetting(uint32_t settings_id)

--- a/lib/lz4/longtail_lz4.h
+++ b/lib/lz4/longtail_lz4.h
@@ -9,6 +9,7 @@ extern "C" {
 
 LONGTAIL_EXPORT extern struct Longtail_CompressionAPI* Longtail_CreateLZ4CompressionAPI();
 LONGTAIL_EXPORT extern uint32_t Longtail_GetLZ4DefaultQuality();
+LONGTAIL_EXPORT extern struct Longtail_CompressionAPI* Longtail_CompressionRegistry_CreateForLZ4(uint32_t compression_type, uint32_t* out_settings);
 
 #ifdef __cplusplus
 }

--- a/lib/zstd/longtail_zstd.c
+++ b/lib/zstd/longtail_zstd.c
@@ -9,16 +9,22 @@
 
 
 const int LONGTAIL_ZSTD_MIN_COMPRESSION_LEVEL      = 0;
+const int LONGTAIL_ZSTD_LOW_COMPRESSION_TYPE       = 2;
 const int LONGTAIL_ZSTD_DEFAULT_COMPRESSION_LEVEL  = ZSTD_CLEVEL_DEFAULT;
+const int LONGTAIL_ZSTD_HIGH_COMPRESSION_LEVEL     = 8;
 const int LONGTAIL_ZSTD_MAX_COMPRESSION_LEVEL      = ZSTD_MAX_CLEVEL;
 
 #define LONGTAIL_ZSTD_MIN_COMPRESSION_TYPE     ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'1'))
 #define LONGTAIL_ZSTD_DEFAULT_COMPRESSION_TYPE ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'2'))
 #define LONGTAIL_ZSTD_MAX_COMPRESSION_TYPE     ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'3'))
+#define LONGTAIL_ZSTD_HIGH_COMPRESSION_TYPE     ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'4'))
+#define LONGTAIL_ZSTD_LOW_COMPRESSION_TYPE     ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'5'))
 
 uint32_t Longtail_GetZStdMinQuality() { return LONGTAIL_ZSTD_MIN_COMPRESSION_TYPE; }
 uint32_t Longtail_GetZStdDefaultQuality() { return LONGTAIL_ZSTD_DEFAULT_COMPRESSION_TYPE; }
 uint32_t Longtail_GetZStdMaxQuality() { return LONGTAIL_ZSTD_MAX_COMPRESSION_TYPE; }
+uint32_t Longtail_GetZStdHighQuality() { return LONGTAIL_ZSTD_HIGH_COMPRESSION_TYPE; }
+uint32_t Longtail_GetZStdLowQuality() { return LONGTAIL_ZSTD_LOW_COMPRESSION_TYPE; }
 
 static int SettingsIDToCompressionSetting(uint32_t settings_id)
 {
@@ -30,6 +36,10 @@ static int SettingsIDToCompressionSetting(uint32_t settings_id)
             return LONGTAIL_ZSTD_DEFAULT_COMPRESSION_LEVEL;
         case LONGTAIL_ZSTD_MAX_COMPRESSION_TYPE:
             return LONGTAIL_ZSTD_MAX_COMPRESSION_LEVEL;
+        case LONGTAIL_ZSTD_HIGH_COMPRESSION_TYPE:
+            return LONGTAIL_ZSTD_HIGH_COMPRESSION_LEVEL;
+        case LONGTAIL_ZSTD_LOW_COMPRESSION_TYPE:
+            return LONGTAIL_ZSTD_LOW_COMPRESSION_TYPE;
        default:
            return 0;
     }

--- a/lib/zstd/longtail_zstd.c
+++ b/lib/zstd/longtail_zstd.c
@@ -14,17 +14,31 @@ const int LONGTAIL_ZSTD_DEFAULT_COMPRESSION_LEVEL  = ZSTD_CLEVEL_DEFAULT;
 const int LONGTAIL_ZSTD_HIGH_COMPRESSION_LEVEL     = 8;
 const int LONGTAIL_ZSTD_MAX_COMPRESSION_LEVEL      = ZSTD_MAX_CLEVEL;
 
-#define LONGTAIL_ZSTD_MIN_COMPRESSION_TYPE     ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'1'))
-#define LONGTAIL_ZSTD_DEFAULT_COMPRESSION_TYPE ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'2'))
-#define LONGTAIL_ZSTD_MAX_COMPRESSION_TYPE     ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'3'))
-#define LONGTAIL_ZSTD_HIGH_COMPRESSION_TYPE     ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'4'))
-#define LONGTAIL_ZSTD_LOW_COMPRESSION_TYPE     ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8) + ((uint32_t)'5'))
+#define LONGTAIL_ZSTD_COMPRESSION_TYPE         ((((uint32_t)'z') << 24) + (((uint32_t)'t') << 16) + (((uint32_t)'d') << 8))
+#define LONGTAIL_ZSTD_MIN_COMPRESSION_TYPE     (LONGTAIL_ZSTD_COMPRESSION_TYPE + ((uint32_t)'1'))
+#define LONGTAIL_ZSTD_DEFAULT_COMPRESSION_TYPE (LONGTAIL_ZSTD_COMPRESSION_TYPE + ((uint32_t)'2'))
+#define LONGTAIL_ZSTD_MAX_COMPRESSION_TYPE     (LONGTAIL_ZSTD_COMPRESSION_TYPE + ((uint32_t)'3'))
+#define LONGTAIL_ZSTD_HIGH_COMPRESSION_TYPE    (LONGTAIL_ZSTD_COMPRESSION_TYPE + ((uint32_t)'4'))
+#define LONGTAIL_ZSTD_LOW_COMPRESSION_TYPE     (LONGTAIL_ZSTD_COMPRESSION_TYPE + ((uint32_t)'5'))
 
 uint32_t Longtail_GetZStdMinQuality() { return LONGTAIL_ZSTD_MIN_COMPRESSION_TYPE; }
 uint32_t Longtail_GetZStdDefaultQuality() { return LONGTAIL_ZSTD_DEFAULT_COMPRESSION_TYPE; }
 uint32_t Longtail_GetZStdMaxQuality() { return LONGTAIL_ZSTD_MAX_COMPRESSION_TYPE; }
 uint32_t Longtail_GetZStdHighQuality() { return LONGTAIL_ZSTD_HIGH_COMPRESSION_TYPE; }
 uint32_t Longtail_GetZStdLowQuality() { return LONGTAIL_ZSTD_LOW_COMPRESSION_TYPE; }
+
+struct Longtail_CompressionAPI* Longtail_CompressionRegistry_CreateForZstd(uint32_t compression_type, uint32_t* out_settings)
+{
+    if ((compression_type & 0xffffff00) != LONGTAIL_ZSTD_COMPRESSION_TYPE)
+    {
+        return 0;
+    }
+    if (out_settings)
+    {
+        *out_settings = compression_type;
+    }
+    return Longtail_CreateZStdCompressionAPI();
+}
 
 static int SettingsIDToCompressionSetting(uint32_t settings_id)
 {

--- a/lib/zstd/longtail_zstd.h
+++ b/lib/zstd/longtail_zstd.h
@@ -13,6 +13,7 @@ LONGTAIL_EXPORT extern uint32_t Longtail_GetZStdDefaultQuality();
 LONGTAIL_EXPORT extern uint32_t Longtail_GetZStdMaxQuality();
 LONGTAIL_EXPORT extern uint32_t Longtail_GetZStdHighQuality();
 LONGTAIL_EXPORT extern uint32_t Longtail_GetZStdLowQuality();
+LONGTAIL_EXPORT extern struct Longtail_CompressionAPI* Longtail_CompressionRegistry_CreateForZstd(uint32_t compression_type, uint32_t* out_settings);
 
 #ifdef __cplusplus
 }

--- a/lib/zstd/longtail_zstd.h
+++ b/lib/zstd/longtail_zstd.h
@@ -11,6 +11,8 @@ LONGTAIL_EXPORT extern struct Longtail_CompressionAPI* Longtail_CreateZStdCompre
 LONGTAIL_EXPORT extern uint32_t Longtail_GetZStdMinQuality();
 LONGTAIL_EXPORT extern uint32_t Longtail_GetZStdDefaultQuality();
 LONGTAIL_EXPORT extern uint32_t Longtail_GetZStdMaxQuality();
+LONGTAIL_EXPORT extern uint32_t Longtail_GetZStdHighQuality();
+LONGTAIL_EXPORT extern uint32_t Longtail_GetZStdLowQuality();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- **CHANGED API** `Longtail_CreateDefaultCompressionRegistry` is now takes callback functions to create compression apis, this makes it possible to add new compression settings for a compression type without breaking older versions
- **NEW API** `Longtail_GetZStdHighQuality`, `Longtail_GetZStdLowQuality` added
- **NEW API** `Longtail_CompressionRegistry_CreateForBrotli`, `Longtail_CompressionRegistry_CreateForLZ4`, `Longtail_CompressionRegistry_CreateForZstd`
