### PR TITLE
Additional store/version index error diagnostics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ##
+- **CHANGED** Additional error/diagnostic logging when initialising store and version indexes from a buffer
 
 ## 0.3.6
 - **CHANGED API** `Longtail_Job_CreateJobsFunc` now takes a `channel` parameter, can be either 0 or 1, 0 has higher priority than 1

--- a/cmd/main.c
+++ b/cmd/main.c
@@ -1048,7 +1048,7 @@ int ValidateVersionIndex(
         &block_store_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create retarget store index for version index `%s` to `%s`", storage_uri_raw, version_index_path, err);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create retarget store index for version index `%s` to `%s`, failed with %d", storage_uri_raw, version_index_path, err);
         Longtail_Free(version_index);
         SAFE_DISPOSE_API(store_block_api);
         SAFE_DISPOSE_API(storage_api);
@@ -1299,7 +1299,7 @@ int VersionIndex_cp(
         &block_store_store_index);
     if (err)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create retarget store index for version index `%s` to `%s`", storage_uri_raw, version_index_path, err);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "Failed to create retarget store index for version index `%s` to `%s`, failed with %d", storage_uri_raw, version_index_path, err);
         SAFE_DISPOSE_API(store_block_store_api);
         SAFE_DISPOSE_API(lru_block_store_api);
         SAFE_DISPOSE_API(compress_block_store_api);

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -2360,9 +2360,9 @@ static int InitVersionIndexFromData(
     version_index->m_Version = (uint32_t*)(void*)p;
     p += sizeof(uint32_t);
 
-    if ((*version_index->m_Version) != LONGTAIL_VERSION_INDEX_VERSION_0_0_2)
+    if ((*version_index->m_Version) != Longtail_CurrentVersionIndexVersion)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Missmatching versions in version index data %" PRIu64 " != %" PRIu64 "", (void*)version_index->m_Version, Longtail_CurrentVersionIndexVersion);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Mismatching versions in version index data %" PRIu64 " != %" PRIu64 "", (void*)version_index->m_Version, Longtail_CurrentVersionIndexVersion);
         return EBADF;
     }
 
@@ -2387,10 +2387,10 @@ static int InitVersionIndexFromData(
 
     uint32_t asset_chunk_index_count = *version_index->m_AssetChunkIndexCount;
 
-    size_t versiom_index_data_size = Longtail_GetVersionIndexDataSize(asset_count, chunk_count, asset_chunk_index_count, 0);
-    if (versiom_index_data_size > data_size)
+    size_t version_index_data_size = Longtail_GetVersionIndexDataSize(asset_count, chunk_count, asset_chunk_index_count, 0);
+    if (version_index_data_size > data_size)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Version index data is truncated: %" PRIu64 " <= %" PRIu64, data_size, versiom_index_data_size)
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Version index data is truncated: %" PRIu64 " <= %" PRIu64, data_size, version_index_data_size)
         return EBADF;
     }
 
@@ -3021,7 +3021,7 @@ int Longtail_InitBlockIndexFromData(
     size_t block_index_data_size = Longtail_GetBlockIndexDataSize(chunk_count);
     if (block_index_data_size > data_size)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Chunk count results in block index data %" PRIu64 " larger that data size (%" PRIu64 ")", block_index_data_size, data)
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Chunk count results in block index data %" PRIu64 " larger that data size (%" PRIu64 ")", block_index_data_size, data_size)
         return EBADF;
     }
 
@@ -7550,10 +7550,12 @@ static int InitStoreIndexFromData(
     size_t store_index_data_size = Longtail_GetStoreIndexDataSize(block_count, chunk_count);
     if (store_index_data_size > data_size)
     {
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Store index data is truncated: %" PRIu64 " <= %" PRIu64, data_size, store_index_data_size)
         return EBADF;
     }
-    if (*store_index->m_Version != LONGTAIL_STORE_INDEX_VERSION_1_0_0)
+    if (*store_index->m_Version != Longtail_CurrentStoreIndexVersion)
     {
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Mismatching versions in version index data %" PRIu64 " != %" PRIu64 "", (void*)store_index->m_Version, Longtail_CurrentStoreIndexVersion);
         return EBADF;
     }
 

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -7555,7 +7555,7 @@ static int InitStoreIndexFromData(
     }
     if (*store_index->m_Version != Longtail_CurrentStoreIndexVersion)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Mismatching versions in version index data %" PRIu64 " != %" PRIu64 "", (void*)store_index->m_Version, Longtail_CurrentStoreIndexVersion);
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Mismatching versions in store index data %" PRIu64 " != %" PRIu64 "", (void*)store_index->m_Version, Longtail_CurrentStoreIndexVersion);
         return EBADF;
     }
 


### PR DESCRIPTION
- I'm seeing a number of sporadic errors presenting as follows, which cause the store to be entirely rebuilt. The current working theory is that this could perhaps be the result of two simulations `upsync` actions to the same store.
- This PR adds some additional diagnostics to help isolate the cause of the `9: Bad file descriptor` error code:
```
level=info msg="read store index items" client="gs://builds/client/Windows-x86_64/stores/longtail/" fname=readStoreStoreIndexWithItems items="[store.lsi]"
level=info msg="read 260046848 bytes" client="gs://builds/client/Windows-x86_64/stores/longtail/" fname=ReadBlobWithRetry key=store.lsi
level=error msg="InitStoreIndexFromData() failed with 9" buffer=000000c0283c6000 file="D:\\a\\longtail\\longtail\\src\\longtail.c" func=Longtail_ReadStoreIndexFromBuffer line=8165 out_store_index=000000c000214080 size=260046848
level=info msg="Failed reading existsing store index" accessType=1 blobStore="gs://builds/client/Windows-x86_64/stores/longtail/" client="gs://builds/client/Windows-x86_64/stores/longtail/" error="readStoreStoreIndexWithItems: mergeStoreIndexItems: readStoreStoreIndexFromPath: Cant parse store index from `store.lsi`: ReadStoreIndexFromBuffer: 9: Bad file descriptor." fname=readRemoteStoreIndex workerCount=16
level=info msg="bulding store index from blocks" accessType=1 blobStore="gs://builds/client/Windows-x86_64/stores/longtail/" client="gs://builds/client/Windows-x86_64/stores/longtail/" fname=readRemoteStoreIndex workerCount=16
```