### PR TITLE
allocate proper size for string when adding long path prefix on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ##
 - **CHANGED** Additional error/diagnostic logging when initialising store and version indexes from a buffer
+- **FIX** Allocated proper size when adding long file path prefix Issue #211
 - **FIX** Don't use potentally stale store index in `FSBlockStoreAPI` `PruneBlocks`
 
 ## 0.3.6

--- a/lib/longtail_platform.c
+++ b/lib/longtail_platform.c
@@ -142,7 +142,7 @@ static const wchar_t* MakeLongPath(const wchar_t* path)
     }
     static const wchar_t* LongPathPrefix = L"\\\\?\\";
     size_t long_path_len = wcslen(path) + 4 + 1;
-    wchar_t* long_path = (wchar_t*)Longtail_Alloc("MakeLongPath", long_path_len);
+    wchar_t* long_path = (wchar_t*)Longtail_Alloc("MakeLongPath", long_path_len * sizeof(wchar_t));
     wcsncpy(long_path, LongPathPrefix, 4);
     wcscpy(&long_path[4], path);
     return long_path;


### PR DESCRIPTION
closes #211 