### PR TITLE
Paths in a version index are now stored with case sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ##
+- **CHANGED** Paths in a version index is now stored with case sensitivity to avoid confusion when a file is renamed by changing casing only
+- **FIX** Changing case of a file name without changing name no longer causes EACCESS error form version index adding the same file twice with same casing
 - **UPDATED** Update of ZStd: 1.5.4 https://github.com/facebook/zstd/releases/tag/v1.5.4
 - **UPDATED** Update of LZ4: 1.9.4 https://github.com/lz4/lz4/releases/tag/v1.9.4
 - **UPDATED** Update of Blake3: 1.3.3 https://github.com/BLAKE3-team/BLAKE3/releases/tag/1.3.3

--- a/lib/memstorage/longtail_memstorage.c
+++ b/lib/memstorage/longtail_memstorage.c
@@ -110,23 +110,12 @@ static void InMemStorageAPI_Dispose(struct Longtail_API* storage_api)
     Longtail_Free(storage_api);
 }
 
-static void InMemStorageAPI_ToLowerCase(char *str)
-{
-    for ( ; *str; ++str)
-    {
-        *str = tolower(*str);
-    }
-}
-
 static const uint32_t Seed  = 0x811C9DC5;
 
 static uint32_t InMemStorageAPI_GetPathHash(const char* path)
 {
     uint32_t pathlen = (uint32_t)strlen(path);
-    char* buf = (char*)alloca(pathlen + 1);
-    memcpy(buf, path, pathlen + 1);
-    InMemStorageAPI_ToLowerCase(buf);
-    return murmur3_32((const uint8_t*)buf, pathlen, Seed);
+    return murmur3_32((const uint8_t*)path, pathlen, Seed);
 }
 
 static int InMemStorageAPI_OpenReadFile(struct Longtail_StorageAPI* storage_api, const char* path, Longtail_StorageAPI_HOpenFile* out_open_file)

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -2344,6 +2344,12 @@ static int InitVersionIndexFromData(
 
     char* p = (char*)data;
 
+    if (data_size < (6 * sizeof(uint32_t)))
+    {
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_WARNING, "Version index is invalid, not big enough for minimal header. Size %" PRIu64 " < %" PRIu64 "", data_size, (6 * sizeof(uint32_t)));
+        return EBADF;
+    }
+
     size_t version_index_data_start = (size_t)(uintptr_t)p;
 
     version_index->m_Version = (uint32_t*)(void*)p;

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -1094,14 +1094,6 @@ struct Longtail_LookupTable* LongtailPrivate_LookupTable_Create(void* mem, uint3
     return lut;
 }
 
-static void Longtail_ToLowerCase(char *str)
-{
-    for ( ; *str; ++str)
-    {
-        *str = tolower(*str);
-    }
-}
-
 static int IsDirPath(const char* path)
 {
 #if defined(LONGTAIL_ASSERTS)
@@ -1132,11 +1124,8 @@ int LongtailPrivate_GetPathHash(struct Longtail_HashAPI* hash_api, const char* p
     LONGTAIL_FATAL_ASSERT(ctx, path != 0, return EINVAL)
     LONGTAIL_FATAL_ASSERT(ctx, out_hash != 0, return EINVAL)
     uint32_t pathlen = (uint32_t)strlen(path);
-    char* buf = (char*)alloca(pathlen + 1);
-    memcpy(buf, path, pathlen + 1);
-    Longtail_ToLowerCase(buf);
     uint64_t hash;
-    int err = hash_api->HashBuffer(hash_api, pathlen, (void*)buf, &hash);
+    int err = hash_api->HashBuffer(hash_api, pathlen, (void*)path, &hash);
     if (err)
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "hash_api->HashBuffer() failed with %d", err)


### PR DESCRIPTION
- **CHANGED** Paths in a version index are now stored with case sensitivity to avoid confusion when a file is renamed by changing casing only
- **FIX** Changing case of a file name without changing name no longer causes EACCESS error form version index adding the same file twice with same casing

Changing case of a file will cause rewrite of the file, even on Windows. No extra storage is required but the file will be deleted and then created.
Having a filename with the same path but different casing will still cause issues on Windows as it might try to write both paths at the same time.
This is not really supported on Windows and should be avoided. I may add an error message for this in the future, but requires re-hashing all paths to validate and I don't want to add the overhead unless strictly necessary.