### PR TITLE
NativeCreateDirectory: avoid infinite loop if long_path is a UNC path

### DIFF
--- a/lib/longtail_platform.c
+++ b/lib/longtail_platform.c
@@ -426,7 +426,7 @@ static DWORD NativeCreateDirectory(wchar_t* long_path)
             return ERROR_SUCCESS;
         }
         DWORD last_error = GetLastError();
-        if (last_error == ERROR_FILE_EXISTS || last_error == ERROR_ALREADY_EXISTS)
+        if (last_error == ERROR_FILE_EXISTS || last_error == ERROR_ALREADY_EXISTS || last_error == ERROR_ACCESS_DENIED)
         {
             return last_error;
         }


### PR DESCRIPTION
One of our users (context: #211) discovered an infinite loop in longtail when `target-path`:
1. Is specified as a UNC path
2. Is directly under a root drive (C:, D:, ...)
3. Does not already exist

The behavior can be observed on Windows 11 and 10 in both golongtail and our custom GUI client that links the longtail lib:
`cmd\longtail\longtail.exe get --source-path Test.json --target-path \\?\C:\Test`

The application hangs in an infinite loop because:
* `NativeCreateDirectory` attempts to create the parent directory to `\\?\C:\Test` which is `\\?\C:`
* With vanilla Windows paths this returns `ERROR_ALREADY_EXISTS`
* With UNC paths this returns `ERROR_ACCESS_DENIED` (which was not previously accounted for)

Provided here is a "hotfix" that simply avoids the infinite loop by erroring out with "Access denied". Presumably this should also fix cases where a user legitimately does not have access privileges to create the directory.

Please note that this is not a complete/correct fix since longtail will still fail to create `\\?\C:\Test`, it will just avoid the infinite loop.

I'm not sure what the "proper" fix is since the docs for `CreateDirectoryW` seems to imply UNC paths are supported -- I guess both `ERROR_ALREADY_EXISTS` and `ERROR_ACCESS_DENIED` could be argued correct when trying to create a special root path?