### PR TITLE
batch jobs in Longtail_ChangeVersion2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@
 - **ADDED** memtracer now tracks allocations in stb_ds
 - **ADDED** memtracer now tracks allocations in zstd
 - **NEW API** `Longtail_CompareAndSwap` compare and swap with platform implementations
+- **NEW API** `Longtail_RunJobsBatched` runs jobs in batched mode to handle a job count larger than Longtail_JobAPI::GetMaxBatchCount()
 - **FIXED** Fixed memory leaks in command tool
+- **FIXED** `Longtail_ChangeVersion2()` can now handle workloads with a block count larger than 65535
+- **FIXED** Bikeshed JobAPI implementation does efficient wait when task queue is full
+- **FIXED** Bikeshed JobAPI::CreateJobs implementation now properly drains both task channels when task queue is full
 - **CHANGED** Refactored all internal usage of JobAPI `ReadyJobs` with new error handling
 
 ## 0.4.1

--- a/lib/bikeshed/longtail_bikeshed.c
+++ b/lib/bikeshed/longtail_bikeshed.c
@@ -416,8 +416,9 @@ static int Bikeshed_CreateJobs(
 
     Longtail_AtomicAdd32(&bikeshed_job_group->m_PendingJobCount, (int)job_count);
 
+    int detected_error = bikeshed_job_group->m_DetectedError;
     *out_jobs = task_ids;
-    err = 0;
+    err = detected_error;
 end:
     Longtail_Free(work_mem);
     return err;

--- a/lib/bikeshed/longtail_bikeshed.c
+++ b/lib/bikeshed/longtail_bikeshed.c
@@ -388,18 +388,20 @@ static int Bikeshed_CreateJobs(
 
     while (!Bikeshed_CreateTasks(bikeshed_job_api->m_Shed, job_count, funcs, ctxs, task_ids))
     {
-        if (bikeshed_job_group->m_DetectedError == 0)
+        err = bikeshed_job_group->m_DetectedError;
+        if (err)
         {
-            if (progressAPI && is_reserve_thread)
+            goto on_error;
+        }
+        if (progressAPI && is_reserve_thread)
+        {
+            progressAPI->OnProgress(progressAPI,(uint32_t)bikeshed_job_group->m_ReservedJobCount, (uint32_t)bikeshed_job_group->m_JobsCompleted);
+        }
+        if (optional_cancel_api && optional_cancel_token)
+        {
+            if (optional_cancel_api->IsCancelled(optional_cancel_api, optional_cancel_token) == ECANCELED)
             {
-                progressAPI->OnProgress(progressAPI,(uint32_t)bikeshed_job_group->m_ReservedJobCount, (uint32_t)bikeshed_job_group->m_JobsCompleted);
-            }
-            if (optional_cancel_api && optional_cancel_token)
-            {
-                if (optional_cancel_api->IsCancelled(optional_cancel_api, optional_cancel_token) == ECANCELED)
-                {
-                    Longtail_CompareAndSwap(&bikeshed_job_group->m_DetectedError, 0, ECANCELED);
-                }
+                Longtail_CompareAndSwap(&bikeshed_job_group->m_DetectedError, 0, ECANCELED);
             }
         }
         if (Bikeshed_ExecuteOne(bikeshed_job_api->m_Shed, 0))
@@ -412,13 +414,12 @@ static int Bikeshed_CreateJobs(
         }
         Longtail_WaitSema(bikeshed_job_api->m_ReadyCallback.m_Semaphore, 100);
     }
-    Bikeshed_SetTasksChannel(bikeshed_job_api->m_Shed, job_count, task_ids, job_channel);
 
+    Bikeshed_SetTasksChannel(bikeshed_job_api->m_Shed, job_count, task_ids, job_channel);
     Longtail_AtomicAdd32(&bikeshed_job_group->m_PendingJobCount, (int)job_count);
 
-    int detected_error = bikeshed_job_group->m_DetectedError;
+    err = 0;
     *out_jobs = task_ids;
-    err = detected_error;
 end:
     Longtail_Free(work_mem);
     return err;

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -960,6 +960,7 @@ int Longtail_RunJobsBatched(
 
     LONGTAIL_VALIDATE_INPUT(ctx, job_api != 0, return EINVAL)
     LONGTAIL_VALIDATE_INPUT(ctx, job_funcs != 0, return EINVAL)
+    LONGTAIL_VALIDATE_INPUT(ctx, total_job_count > 0, return EINVAL)
     LONGTAIL_VALIDATE_INPUT(ctx, job_ctxs != 0, return EINVAL)
     LONGTAIL_VALIDATE_INPUT(ctx, out_jobs_submitted != 0, return EINVAL)
 
@@ -2264,22 +2265,12 @@ static int ChunkAssets(
         uint64_t asset_size = file_infos->m_Sizes[asset_index];
         uint64_t asset_part_count = 1 + (asset_size / max_hash_size);
         job_count += (uint32_t)asset_part_count;
-        }
+    }
 
     if (job_count == 0)
     {
         return 0;
     }
-
-//    uint32_t max_job_batch_count = 0;
-//    int err = job_api->GetMaxBatchCount(job_api, &max_job_batch_count, 0);
-//    if (err)
-//    {
-//        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "job_api->GetMaxBatchCount() failed with %d", err)
-//        return err;
-//    }
-//    // Adjust how many we submit each time so we get some overlap when tasks free up so we don't stall on each batch
-//    max_job_batch_count /= 2;
 
     size_t work_mem_size = (sizeof(uint32_t) * job_count) +
         (sizeof(struct HashJob) * job_count) +

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -529,7 +529,7 @@ struct Longtail_JobAPI
     Longtail_Job_ReadyJobsFunc ReadyJobs;
     Longtail_Job_WaitForAllJobsFunc WaitForAllJobs;
     Longtail_Job_ResumeJobFunc ResumeJob;
-    Longtail_Job_GetMaxBatchCountFunc GetMaxBatchCountFunc;
+    Longtail_Job_GetMaxBatchCountFunc GetMaxBatchCount;
 };
 
 LONGTAIL_EXPORT uint64_t Longtail_GetJobAPISize();

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -953,6 +953,30 @@ LONGTAIL_EXPORT int EnsureParentPathExists(struct Longtail_StorageAPI* storage_a
  */
 LONGTAIL_EXPORT char* Longtail_Strdup(const char* str);
 
+/*! @brief Runs jobs in batched more.
+ *
+ * Runs the jobs using the job_api submitting the jobs in batches to handle job counts that exceeds Longtail_JobAPI::GetMaxBatchCount()
+ *
+ * @param[in] job_api               An implementation of struct Longtail_JobAPI interface
+ * @param[in] progress_api          An implementation of struct Longtail_JobAPI interface or null if no progress indication is required
+ * @param[in] optional_cancel_api   An implementation of struct Longtail_CancelAPI interface or null if no cancelling is required
+ * @param[in] optional_cancel_token A cancel token or null if @p optional_cancel_api is null
+ * @param[in] total_job_count       Total number of jobs to execute
+ * @param[in] job_funcs             Array of job functions to execute, array must be at least of size @p total_job_count
+ * @param[in] job_ctxs              Array of job contexts for job functions, array must be at least of size @p total_job_count
+ * @param[out] out_jobs_submitted   Number of jobs submitted (and executed), this may be less than @p total_job_count if an error occurs
+ * @return                          Return code (errno style), zero on success
+ */
+LONGTAIL_EXPORT int Longtail_RunJobsBatched(
+    struct Longtail_JobAPI* job_api,
+    struct Longtail_ProgressAPI* progress_api,
+    struct Longtail_CancelAPI* optional_cancel_api,
+    Longtail_CancelAPI_HCancelToken optional_cancel_token,
+    uint32_t total_job_count,
+    Longtail_JobAPI_JobFunc * job_funcs,
+    void** job_ctxs,
+    uint32_t * out_jobs_submitted);
+
 /*! @brief Get all files and directories in a path recursivley.
  *
  * Gets all the files and directories and allocates a struct Longtail_FileInfos structure with the details.

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -953,7 +953,7 @@ LONGTAIL_EXPORT int EnsureParentPathExists(struct Longtail_StorageAPI* storage_a
  */
 LONGTAIL_EXPORT char* Longtail_Strdup(const char* str);
 
-/*! @brief Runs jobs in batched more.
+/*! @brief Runs jobs in batched mode.
  *
  * Runs the jobs using the job_api submitting the jobs in batches to handle job counts that exceeds Longtail_JobAPI::GetMaxBatchCount()
  *


### PR DESCRIPTION
- **NEW API** `Longtail_RunJobsBatched` runs jobs in batched mode to handle a job count larger than Longtail_JobAPI::GetMaxBatchCount()
- **FIXED** Fixed memory leaks in command tool
- **FIXED** `Longtail_ChangeVersion2()` can now handle workloads with a block count larger than 65535
- **FIXED** Bikeshed JobAPI implementation does efficient wait when task queue is full
- **FIXED** Bikeshed JobAPI::CreateJobs implementation now properly drains both task channels when task queue is full
