### PR TITLE
deterministic sorting in SortPathShortToLongVersionMerge and SortPathhortToLong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **FIXED** `Longtail_ChangeVersion2()` can now handle workloads with a block count larger than 65535
 - **FIXED** Bikeshed JobAPI implementation does efficient wait when task queue is full
 - **FIXED** Bikeshed JobAPI::CreateJobs implementation now properly drains both task channels when task queue is full
+- **FIXED** Make sure we retain order of assets with equal length when sorting them
 - **CHANGED** Refactored all internal usage of JobAPI `ReadyJobs` with new error handling
 
 ## 0.4.1

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -2900,7 +2900,23 @@ static SORTFUNC(SortPathShortToLongVersionMerge)
     uint32_t b = *(const uint32_t*)b_ptr;
     uint32_t a_len = path_lengths[a];
     uint32_t b_len = path_lengths[b];
-    return (a_len > b_len) ? 1 : (a_len < b_len) ? -1 : 0;
+    if (a_len < b_len)
+    {
+        return -1;
+    }
+    if (a_len > b_len)
+    {
+        return 1;
+    }
+    if (a < b)
+    {
+        return -1;
+    }
+    if (a > b)
+    {
+        return 1;
+    }
+    return 0;
 }
 
 int Longtail_MergeVersionIndex(
@@ -7196,7 +7212,23 @@ static SORTFUNC(SortPathShortToLong)
     const char* b_path = &version_index->m_NameData[version_index->m_NameOffsets[b]];
     size_t a_len = strlen(a_path);
     size_t b_len = strlen(b_path);
-    return (a_len > b_len) ? 1 : (a_len < b_len) ? -1 : 0;
+    if (a_len < b_len)
+    {
+        return -1;
+    }
+    if (a_len > b_len)
+    {
+        return 1;
+    }
+    if (a < b)
+    {
+        return -1;
+    }
+    if (a > b)
+    {
+        return 1;
+    }
+    return 0;
 }
 
 static SORTFUNC(SortPathLongToShort)


### PR DESCRIPTION
- **FIXED** Make sure we retain order of assets with equal length when sorting them