### PR TITLE
remove alloc hooks, replaces by realloc hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 - **CHANGED API** `Longtail_JobAPI_JobFunc` renamed `is_cancelled` to `detected_error`, now contains first error returned from a job task in the same job group (if any) or ECANCELLED if job group was cancelled
     If `detected_error` is non-zero, try to exit (and cleanup) your task directly and return `0`.
 - **CHANGED_API** JobAPI `ReadyJobs` now returns first error encountered in a job group for a task as well as any error in the job api itself, removing the need to book keep the error for tasks separately
-- **ADDED** Longtail_SetReAllocAndFree
-- **ADDED** Longtail_ReAlloc
-- **ADDED** Longtail_MemTracer_ReAlloc
 - **ADDED** memtracer now tracks allocations in stb_ds
 - **ADDED** memtracer now tracks allocations in zstd
+- **NEW API** `Longtail_SetReAllocAndFree`
+- **NEW API** `Longtail_ReAlloc`
+- **NEW API** `Longtail_MemTracer_ReAlloc`
 - **NEW API** `Longtail_CompareAndSwap` compare and swap with platform implementations
 - **NEW API** `Longtail_RunJobsBatched` runs jobs in batched mode to handle a job count larger than Longtail_JobAPI::GetMaxBatchCount()
+- **REMOVED API** `Longtail_SetAllocAndFree` is replaced by `Longtail_SetReAllocAndFree`
+- **REMOVED API** `Longtail_MemTracer_Alloc` is replaced by `Longtail_MemTracer_ReAlloc`
 - **FIXED** Fixed memory leaks in command tool
 - **FIXED** `Longtail_ChangeVersion2()` can now handle workloads with a block count larger than 65535
 - **FIXED** Bikeshed JobAPI implementation does efficient wait when task queue is full

--- a/lib/memtracer/longtail_memtracer.c
+++ b/lib/memtracer/longtail_memtracer.c
@@ -374,20 +374,6 @@ void* Longtail_MemTracer_ReAlloc(const char* context, void* old, size_t s)
     return &header_ptr[1];
 }
 
-void* Longtail_MemTracer_Alloc(const char* context, size_t s)
-{
-#if defined(LONGTAIL_ASSERTS)
-    const char* context_safe = context ? context : "";
-    MAKE_LOG_CONTEXT_FIELDS(ctx)
-        LONGTAIL_LOGFIELD(context_safe, "%s"),
-        LONGTAIL_LOGFIELD(s, "%" PRIu64),
-    MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_OFF)
-#else
-    struct Longtail_LogContextFmt_Private* ctx = 0;
-#endif // defined(LONGTAIL_ASSERTS)
-    return Longtail_MemTracer_ReAlloc(context, 0, s);
-}
-
 void Longtail_MemTracer_Free(void* p)
 {
 #if defined(LONGTAIL_ASSERTS)

--- a/lib/memtracer/longtail_memtracer.h
+++ b/lib/memtracer/longtail_memtracer.h
@@ -12,7 +12,6 @@ LONGTAIL_EXPORT extern uint32_t Longtail_GetMemTracerDetailed();
 LONGTAIL_EXPORT void Longtail_MemTracer_Init();
 LONGTAIL_EXPORT char* Longtail_MemTracer_GetStats(uint32_t log_level);
 LONGTAIL_EXPORT void Longtail_MemTracer_Dispose();
-LONGTAIL_EXPORT void* Longtail_MemTracer_Alloc(const char* context, size_t s);
 LONGTAIL_EXPORT void* Longtail_MemTracer_ReAlloc(const char* context, void* old, size_t s);
 LONGTAIL_EXPORT void Longtail_MemTracer_Free(void* p);
 

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -754,15 +754,8 @@ void Longtail_DisposeAPI(struct Longtail_API* api)
     }
 }
 
-static Longtail_Alloc_Func Longtail_Alloc_private = 0;
 static Longtail_ReAlloc_Func Longtail_ReAlloc_private = 0;
 static Longtail_Free_Func Free_private = 0;
-
-void Longtail_SetAllocAndFree(Longtail_Alloc_Func alloc, Longtail_Free_Func Longtail_Free)
-{
-    Longtail_Alloc_private = alloc;
-    Free_private = Longtail_Free;
-}
 
 static void* Longtail_SetAllocWrapper_private(const char* context, size_t s)
 {
@@ -772,26 +765,12 @@ static void* Longtail_SetAllocWrapper_private(const char* context, size_t s)
 void Longtail_SetReAllocAndFree(Longtail_ReAlloc_Func alloc, Longtail_Free_Func Longtail_Free)
 {
     Longtail_ReAlloc_private = alloc;
-    Longtail_Alloc_private = Longtail_SetAllocWrapper_private;
     Free_private = Longtail_Free;
 }
 
 void* Longtail_Alloc(const char* context, size_t s)
 {
-#if defined(LONGTAIL_ASSERTS)
-    MAKE_LOG_CONTEXT_FIELDS(ctx)
-        LONGTAIL_LOGFIELD(s, "%" PRIu64)
-    MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_OFF)
-#else
-    struct Longtail_LogContextFmt_Private* ctx = 0;
-#endif // defined(LONGTAIL_ASSERTS)
-    void* mem = Longtail_Alloc_private ? Longtail_Alloc_private(context, s) : malloc(s);
-    if (!mem)
-    {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "%s failed with %d", Longtail_Alloc_private ? "Longtail_Alloc_private" : "malloc()", ENOMEM);
-        return 0;
-    }
-    return mem;
+    return Longtail_ReAlloc(context, 0, s);
 }
 
 void* Longtail_ReAlloc(const char* context, void* old, size_t s)

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -921,9 +921,7 @@ LONGTAIL_EXPORT int Longtail_GetLogLevel();
     extern void Longtail_STBFree(void* context, void* ptr);
 #endif // STBDS_REALLOC
 
-typedef void* (*Longtail_Alloc_Func)(const char* context, size_t s);
 typedef void (*Longtail_Free_Func)(void* p);
-LONGTAIL_EXPORT void Longtail_SetAllocAndFree(Longtail_Alloc_Func alloc, Longtail_Free_Func free);
 
 LONGTAIL_EXPORT void* Longtail_Alloc(const char* context, size_t s);
 


### PR DESCRIPTION
- **REMOVED API** `Longtail_SetAllocAndFree` is replaced by `Longtail_SetReAllocAndFree`
- **REMOVED API** `Longtail_MemTracer_Alloc` is replaced by `Longtail_MemTracer_ReAlloc`