### PR TITLE
add monitor callbacks for WriteContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - **UPDATED** Update of ZStd: 1.5.5 https://github.com/facebook/zstd/releases/tag/v1.5.5
 - **UPDATED** Update of Blake3: 1.5.0 https://github.com/BLAKE3-team/BLAKE3/releases/tag/1.5.0
 - **UPDATED** Update of Brotli: 1.1.0 https://github.com/google/brotli/releases/tag/v1.1.0
-- **EXPERIMENTAL** **NEW API** `Longtail_SetMonitor` to enable more detailed feedback on `Longtail_ChangeVersion2`. Includes simple progress UI using MiniFB and console output for downsync/unpack via `--detailed-progress` option. MiniFB only works on Windows so far, other platforms fall back to console text output.
+- **EXPERIMENTAL** **NEW API** `Longtail_SetMonitor` to enable more detailed feedback on `Longtail_ChangeVersion2` and `Longtail_WriteContent`. Includes simple progress UI using MiniFB and console output for upsync/downsync/pack/unpack via `--detailed-progress` option. MiniFB version only works on Windows so far, other platforms fall back to console text output.
 
 ## 0.4.1
 - **NEW API** `Longtail_ChangeVersion2` added

--- a/cmd/main.c
+++ b/cmd/main.c
@@ -577,6 +577,7 @@ void InitMonitor(struct Longtail_StoreIndex* store_index, struct Longtail_Versio
     memset(MonitorChunkInfos, 0, MonitorChunkInfosSize);
 
     struct Longtail_Monitor monitor = {
+        sizeof(struct Longtail_Monitor),
         MonitorGetStoredBlockPrepare,
         MonitorGetStoredBlockLoad,
         MonitorGetStoredBlockLoaded,
@@ -585,7 +586,12 @@ void InitMonitor(struct Longtail_StoreIndex* store_index, struct Longtail_Versio
         MonitorAssetOpen,
         MonitorAssetWrite,
         MonitorChunkRead,
-        MonitorAssetComplete
+        MonitorAssetComplete,
+        0,
+        0,
+        0,
+        0,
+        0
     };
     Longtail_SetMonitor(&monitor);
 

--- a/cmd/main.c
+++ b/cmd/main.c
@@ -557,18 +557,21 @@ void InitMonitor(struct Longtail_StoreIndex* store_index, struct Longtail_Versio
     MonitorAssetInfos = (struct AssetInfo*)Longtail_Alloc("Monitor", MonitorAssetInfosSize);
     memset(MonitorAssetInfos, 0, MonitorAssetInfosSize);
 
-    for (uint32_t m = 0; m < *version_diff->m_ModifiedContentCount; m++)
+    if (version_diff)
     {
-        uint32_t a = version_diff->m_TargetContentModifiedAssetIndexes[m];
-        MonitorAssetInfos[a].m_TotalChunkCount = version_index->m_AssetChunkCounts[a];
-        MonitorAssetInfos[a].m_PendingChunkCount = version_index->m_AssetChunkCounts[a];
-    }
+        for (uint32_t m = 0; m < *version_diff->m_ModifiedContentCount; m++)
+        {
+            uint32_t a = version_diff->m_TargetContentModifiedAssetIndexes[m];
+            MonitorAssetInfos[a].m_TotalChunkCount = version_index->m_AssetChunkCounts[a];
+            MonitorAssetInfos[a].m_PendingChunkCount = version_index->m_AssetChunkCounts[a];
+        }
 
-    for (uint32_t m = 0; m < *version_diff->m_TargetAddedCount; m++)
-    {
-        uint32_t a = version_diff->m_TargetAddedAssetIndexes[m];
-        MonitorAssetInfos[a].m_TotalChunkCount = version_index->m_AssetChunkCounts[a];
-        MonitorAssetInfos[a].m_PendingChunkCount = version_index->m_AssetChunkCounts[a];
+        for (uint32_t m = 0; m < *version_diff->m_TargetAddedCount; m++)
+        {
+            uint32_t a = version_diff->m_TargetAddedAssetIndexes[m];
+            MonitorAssetInfos[a].m_TotalChunkCount = version_index->m_AssetChunkCounts[a];
+            MonitorAssetInfos[a].m_PendingChunkCount = version_index->m_AssetChunkCounts[a];
+        }
     }
 
     MonitorChunkInfosCount = (*version_index->m_ChunkCount);
@@ -905,7 +908,8 @@ int UpSync(
     uint32_t hashing_type,
     uint32_t compression_type,
     int enable_mmap_indexing,
-    int enable_mmap_block_store)
+    int enable_mmap_block_store,
+    int enable_detailed_progress)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(storage_uri_raw, "%s"),
@@ -917,7 +921,10 @@ int UpSync(
         LONGTAIL_LOGFIELD(max_chunks_per_block, "%u"),
         LONGTAIL_LOGFIELD(min_block_usage_percent, "%u"),
         LONGTAIL_LOGFIELD(hashing_type, "%u"),
-        LONGTAIL_LOGFIELD(compression_type, "%u")
+        LONGTAIL_LOGFIELD(compression_type, "%u"),
+        LONGTAIL_LOGFIELD(enable_mmap_indexing, "%d"),
+        LONGTAIL_LOGFIELD(enable_mmap_block_store, "%d"),
+        LONGTAIL_LOGFIELD(enable_detailed_progress, "%d")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_DEBUG)
 
     const char* storage_path = NormalizePath(storage_uri_raw);
@@ -1085,7 +1092,12 @@ int UpSync(
         return err;
     }
 
-    struct Longtail_ProgressAPI* progress = MakeProgressAPI("Writing blocks", 5);
+    if (enable_detailed_progress)
+    {
+        InitMonitor(remote_missing_store_index, source_version_index, 0);
+    }
+
+    struct Longtail_ProgressAPI* progress = MakeProgressAPI("Writing blocks", enable_detailed_progress ? 0 : 5);
     if (progress)
     {
         err = Longtail_WriteContent(
@@ -2069,7 +2081,8 @@ int Pack(
     uint32_t min_block_usage_percent,
     uint32_t hashing_type,
     uint32_t compression_type,
-    int enable_mmap_indexing)
+    int enable_mmap_indexing,
+    int enable_detailed_progress)
 {
     MAKE_LOG_CONTEXT_FIELDS(ctx)
         LONGTAIL_LOGFIELD(source_path, "%s"),
@@ -2079,7 +2092,9 @@ int Pack(
         LONGTAIL_LOGFIELD(max_chunks_per_block, "%u"),
         LONGTAIL_LOGFIELD(min_block_usage_percent, "%u"),
         LONGTAIL_LOGFIELD(hashing_type, "%u"),
-        LONGTAIL_LOGFIELD(compression_type, "%u")
+        LONGTAIL_LOGFIELD(compression_type, "%u"),
+        LONGTAIL_LOGFIELD(enable_mmap_indexing, "%d"),
+        LONGTAIL_LOGFIELD(enable_detailed_progress, "%d")
     MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_DEBUG)
 
     struct Longtail_HashRegistryAPI* hash_registry = Longtail_CreateFullHashRegistry();
@@ -2249,7 +2264,12 @@ int Pack(
         return ENOMEM;
     }
 
-    struct Longtail_ProgressAPI* progress = MakeProgressAPI("Writing blocks", 5);
+    if (enable_detailed_progress)
+    {
+        InitMonitor(store_index, source_version_index, 0);
+    }
+
+    struct Longtail_ProgressAPI* progress = MakeProgressAPI("Writing blocks", enable_detailed_progress ? 0 : 5);
     if (progress)
     {
         err = Longtail_WriteContent(
@@ -2637,49 +2657,77 @@ int Unpack(
     return err;
 }
 
-struct UnpackArgs
+void* AsyncThreadedMem = 0;
+
+struct UpSyncArgs
 {
+    const char* storage_uri_raw;
     const char* source_path;
-    const char* target_path;
-    int retain_permissions;
+    const char* optional_source_index_path;
+    const char* target_index_path;
+    uint32_t target_chunk_size;
+    uint32_t target_block_size;
+    uint32_t max_chunks_per_block;
+    uint32_t min_block_usage_percent;
+    uint32_t hashing_type;
+    uint32_t compression_type;
     int enable_mmap_indexing;
-    int enable_mmap_unpacking;
+    int enable_mmap_block_store;
     int enable_detailed_progress;
 };
 
-static int UnpackWorker(void* context)
+static int UpSyncWorker(void* context)
 {
-    struct UnpackArgs* Args = (struct UnpackArgs*)context;
-    int res = Unpack(
+    struct UpSyncArgs* Args = (struct UpSyncArgs*)context;
+    int res = UpSync(
+        Args->storage_uri_raw,
         Args->source_path,
-        Args->target_path,
-        Args->retain_permissions,
+        Args->optional_source_index_path,
+        Args->target_index_path,
+        Args->target_chunk_size,
+        Args->target_block_size,
+        Args->max_chunks_per_block,
+        Args->min_block_usage_percent,
+        Args->hashing_type,
+        Args->compression_type,
         Args->enable_mmap_indexing,
-        Args->enable_mmap_unpacking,
+        Args->enable_mmap_block_store,
         Args->enable_detailed_progress);
     return res;
 }
 
-void* AsyncThreadedMem = 0;
-
-static HLongtail_Thread UnpackThreaded(
+static HLongtail_Thread UpSyncThreaded(
+    const char* storage_uri_raw,
     const char* source_path,
-    const char* target_path,
-    int retain_permissions,
+    const char* optional_source_index_path,
+    const char* target_index_path,
+    uint32_t target_chunk_size,
+    uint32_t target_block_size,
+    uint32_t max_chunks_per_block,
+    uint32_t min_block_usage_percent,
+    uint32_t hashing_type,
+    uint32_t compression_type,
     int enable_mmap_indexing,
-    int enable_mmap_unpacking,
+    int enable_mmap_block_store,
     int enable_detailed_progress)
 {
-    AsyncThreadedMem = Longtail_Alloc("Monitor", sizeof(struct UnpackArgs) + Longtail_GetThreadSize());
-    struct UnpackArgs* Args = (struct UnpackArgs*)AsyncThreadedMem;
+    AsyncThreadedMem = Longtail_Alloc("Monitor", sizeof(struct UpSyncArgs) + Longtail_GetThreadSize());
+    struct UpSyncArgs* Args = (struct UpSyncArgs*)AsyncThreadedMem;
+    Args->storage_uri_raw = storage_uri_raw;
     Args->source_path = source_path;
-    Args->target_path = target_path;
-    Args->retain_permissions = retain_permissions;
+    Args->optional_source_index_path = optional_source_index_path;
+    Args->target_index_path = target_index_path;
+    Args->target_chunk_size = target_chunk_size;
+    Args->target_block_size = target_block_size;
+    Args->max_chunks_per_block = max_chunks_per_block;
+    Args->min_block_usage_percent = min_block_usage_percent;
+    Args->hashing_type = hashing_type;
+    Args->compression_type = compression_type;
     Args->enable_mmap_indexing = enable_mmap_indexing;
-    Args->enable_mmap_unpacking = enable_mmap_unpacking;
+    Args->enable_mmap_block_store = enable_mmap_block_store;
     Args->enable_detailed_progress = enable_detailed_progress;
     HLongtail_Thread MonitorThread = 0;
-    int err = Longtail_CreateThread(&Args[1], UnpackWorker, 0, Args, 0, &MonitorThread);
+    int err = Longtail_CreateThread(&Args[1], UpSyncWorker, 0, Args, 0, &MonitorThread);
     return MonitorThread;
 }
 
@@ -2736,6 +2784,110 @@ static HLongtail_Thread DownSyncThreaded(
     Args->enable_detailed_progress = enable_detailed_progress;
     HLongtail_Thread MonitorThread = 0;
     int err = Longtail_CreateThread(&Args[1], DownSyncWorker, 0, Args, 0, &MonitorThread);
+    return MonitorThread;
+}
+
+struct PackArgs
+{
+    const char* source_path;
+    const char* target_path;
+    uint32_t target_chunk_size;
+    uint32_t target_block_size;
+    uint32_t max_chunks_per_block;
+    uint32_t min_block_usage_percent;
+    uint32_t hashing_type;
+    uint32_t compression_type;
+    int enable_mmap_indexing;
+    int enable_detailed_progress;
+};
+
+static int PackWorker(void* context)
+{
+    struct PackArgs* Args = (struct PackArgs*)context;
+    int res = Pack(
+        Args->source_path,
+        Args->target_path,
+        Args->target_chunk_size,
+        Args->target_block_size,
+        Args->max_chunks_per_block,
+        Args->min_block_usage_percent,
+        Args->hashing_type,
+        Args->compression_type,
+        Args->enable_mmap_indexing,
+        Args->enable_detailed_progress);
+    return res;
+}
+
+static HLongtail_Thread PackThreaded(
+    const char* source_path,
+    const char* target_path,
+    uint32_t target_chunk_size,
+    uint32_t target_block_size,
+    uint32_t max_chunks_per_block,
+    uint32_t min_block_usage_percent,
+    uint32_t hashing_type,
+    uint32_t compression_type,
+    int enable_mmap_indexing,
+    int enable_detailed_progress)
+{
+    AsyncThreadedMem = Longtail_Alloc("Monitor", sizeof(struct PackArgs) + Longtail_GetThreadSize());
+    struct PackArgs* Args = (struct PackArgs*)AsyncThreadedMem;
+    Args->source_path = source_path;
+    Args->target_path = target_path;
+    Args->target_chunk_size = target_chunk_size;
+    Args->target_block_size = target_block_size;
+    Args->max_chunks_per_block = max_chunks_per_block;
+    Args->min_block_usage_percent = min_block_usage_percent;
+    Args->hashing_type = hashing_type;
+    Args->compression_type = compression_type;
+    Args->enable_mmap_indexing = enable_mmap_indexing;
+    Args->enable_detailed_progress = enable_detailed_progress;
+    HLongtail_Thread MonitorThread = 0;
+    int err = Longtail_CreateThread(&Args[1], PackWorker, 0, Args, 0, &MonitorThread);
+    return MonitorThread;
+}
+
+struct UnpackArgs
+{
+    const char* source_path;
+    const char* target_path;
+    int retain_permissions;
+    int enable_mmap_indexing;
+    int enable_mmap_unpacking;
+    int enable_detailed_progress;
+};
+
+static int UnpackWorker(void* context)
+{
+    struct UnpackArgs* Args = (struct UnpackArgs*)context;
+    int res = Unpack(
+        Args->source_path,
+        Args->target_path,
+        Args->retain_permissions,
+        Args->enable_mmap_indexing,
+        Args->enable_mmap_unpacking,
+        Args->enable_detailed_progress);
+    return res;
+}
+
+static HLongtail_Thread UnpackThreaded(
+    const char* source_path,
+    const char* target_path,
+    int retain_permissions,
+    int enable_mmap_indexing,
+    int enable_mmap_unpacking,
+    int enable_detailed_progress)
+{
+    AsyncThreadedMem = Longtail_Alloc("Monitor", sizeof(struct UnpackArgs) + Longtail_GetThreadSize());
+    struct UnpackArgs* Args = (struct UnpackArgs*)AsyncThreadedMem;
+    Args->source_path = source_path;
+    Args->target_path = target_path;
+    Args->retain_permissions = retain_permissions;
+    Args->enable_mmap_indexing = enable_mmap_indexing;
+    Args->enable_mmap_unpacking = enable_mmap_unpacking;
+    Args->enable_detailed_progress = enable_detailed_progress;
+    HLongtail_Thread MonitorThread = 0;
+    int err = Longtail_CreateThread(&Args[1], UnpackWorker, 0, Args, 0, &MonitorThread);
     return MonitorThread;
 }
 
@@ -2824,6 +2976,9 @@ int main(int argc, char** argv)
         bool enable_mmap_block_store_raw = 0;
         kgflags_bool("mmap-block-store", false, "Enable memory mapping of files in block store", false, &enable_mmap_block_store_raw);
 
+        bool enable_detailed_progress_raw = 0;
+        kgflags_bool("detailed-progress", false, "Enable visual activity of blocks and assets", false, &enable_detailed_progress_raw);
+
         if (!kgflags_parse(argc, argv)) {
             kgflags_print_errors();
             kgflags_print_usage();
@@ -2854,11 +3009,16 @@ int main(int argc, char** argv)
             return 1;
         }
 
+        if (enable_detailed_progress_raw)
+        {
+            FrameBufferAPI = Longtail_CreateMiniFBFrameBufferAPI();
+        }
+
         const char* source_path = NormalizePath(source_path_raw);
         const char* source_index = source_index_raw ? NormalizePath(source_index_raw) : 0;
         const char* target_path = NormalizePath(target_path_raw);
 
-        err = UpSync(
+        HLongtail_Thread thread = UpSyncThreaded(
             storage_uri_raw,
             source_path,
             source_index,
@@ -2870,11 +3030,19 @@ int main(int argc, char** argv)
             hashing,
             compression,
             enable_mmap_indexing_raw,
-            enable_mmap_block_store_raw);
+            enable_mmap_block_store_raw,
+            enable_detailed_progress_raw);
+        while (TryEndAsyncThread(thread))
+        {
+            UpdateProgressWindow();
+        }
+        DisposeMonitor();
 
         Longtail_Free((void*)source_path);
         Longtail_Free((void*)source_index);
         Longtail_Free((void*)target_path);
+
+        SAFE_DISPOSE_API(FrameBufferAPI);
     }
     else if (strcmp(command, "downsync") == 0)
     {
@@ -3109,6 +3277,9 @@ int main(int argc, char** argv)
         bool enable_mmap_indexing_raw = 0;
         kgflags_bool("mmap-indexing", false, "Enable memory mapping of files while indexing", false, &enable_mmap_indexing_raw);
 
+        bool enable_detailed_progress_raw = 0;
+        kgflags_bool("detailed-progress", false, "Enable visual activity of blocks and assets", false, &enable_detailed_progress_raw);
+
         if (!kgflags_parse(argc, argv)) {
             kgflags_print_errors();
             kgflags_print_usage();
@@ -3139,11 +3310,15 @@ int main(int argc, char** argv)
             return 1;
         }
 
-        const char* source_path = NormalizePath(source_path_raw);
+        if (enable_detailed_progress_raw)
+        {
+            FrameBufferAPI = Longtail_CreateMiniFBFrameBufferAPI();
+        }
 
+        const char* source_path = NormalizePath(source_path_raw);
         const char* target_path = NormalizePath(target_path_raw);
 
-        err = Pack(
+        HLongtail_Thread thread = PackThreaded(
             source_path,
             target_path,
             target_chunk_size,
@@ -3152,10 +3327,18 @@ int main(int argc, char** argv)
             min_block_usage_percent,
             hashing,
             compression,
-            enable_mmap_indexing_raw);
+            enable_mmap_indexing_raw,
+            enable_detailed_progress_raw);
+        while (TryEndAsyncThread(thread))
+        {
+            UpdateProgressWindow();
+        }
+        DisposeMonitor();
 
         Longtail_Free((void*)source_path);
         Longtail_Free((void*)target_path);
+
+        SAFE_DISPOSE_API(FrameBufferAPI);
     }
     if (strcmp(command, "unpack") == 0)
     {

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -753,6 +753,13 @@ static struct Longtail_Monitor Monitor_private = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 
 void Longtail_SetMonitor(struct Longtail_Monitor* monitor)
 {
+    MAKE_LOG_CONTEXT_FIELDS(ctx)
+        LONGTAIL_LOGFIELD(monitor, "%p")
+    MAKE_LOG_CONTEXT_WITH_FIELDS(ctx, 0, LONGTAIL_LOG_LEVEL_DEBUG)
+
+    LONGTAIL_VALIDATE_INPUT(ctx, monitor != 0, return)
+    LONGTAIL_VALIDATE_INPUT(ctx, monitor->StructSize == (uint64_t)sizeof(struct Longtail_Monitor), return)
+
     Monitor_private = *monitor;
 }
 

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -731,7 +731,7 @@ int Longtail_BlockStore_PruneBlocks(struct Longtail_BlockStoreAPI* block_store_a
 int Longtail_BlockStore_GetStats(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_BlockStore_Stats* out_stats) { return block_store_api->GetStats(block_store_api, out_stats); }
 int Longtail_BlockStore_Flush(struct Longtail_BlockStoreAPI* block_store_api, struct Longtail_AsyncFlushAPI* async_complete_api) {return block_store_api->Flush(block_store_api, async_complete_api); }
 
-static struct Longtail_Monitor Monitor_private = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+static struct Longtail_Monitor Monitor_private = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 #define LONGTAIL_MONTITOR_BLOCK_PREPARE(store_index, block_index) if (Monitor_private.BlockPrepare) {Monitor_private.BlockPrepare(store_index, block_index);}
 #define LONGTAIL_MONTITOR_BLOCK_LOAD(store_index, block_index) if (Monitor_private.BlockLoad) {Monitor_private.BlockLoad(store_index, block_index);}
@@ -744,6 +744,12 @@ static struct Longtail_Monitor Monitor_private = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 #define LONGTAIL_MONTITOR_ASSET_COMPLETE(version_index, asset_index, err) if (Monitor_private.AssetComplete) {Monitor_private.AssetComplete(version_index, asset_index, err);};
 
 #define LONGTAIL_MONTITOR_CHUNK_READ(store_index, version_index, block_index, chunk_index, chunk_index_in_block) if (Monitor_private.ChunkRead) {Monitor_private.ChunkRead(store_index, version_index, block_index, chunk_index, chunk_index_in_block);}
+
+#define LONGTAIL_MONTITOR_BLOCK_COMPOSE(store_index, block_index) if (Monitor_private.BlockCompose) {Monitor_private.BlockCompose(store_index, block_index);}
+#define LONGTAIL_MONTITOR_ASSET_READ(store_index, version_index, asset_index, read_offset, size, chunk_hash, block_index, block_data_offset) if (Monitor_private.AssetRead) {Monitor_private.AssetRead(store_index, version_index, asset_index, read_offset, size, chunk_hash, block_index, block_data_offset);}
+#define LONGTAIL_MONTITOR_ASSET_CLOSE(version_index, asset_index, err) if (Monitor_private.AssetClose) {Monitor_private.AssetClose(version_index, asset_index, err);}
+#define LONGTAIL_MONITOR_BLOCK_SAVE(store_index, block_index, block_size) if (Monitor_private.BlockSave) {Monitor_private.BlockSave(store_index, block_index, block_size);}
+#define LONGTAIL_MONITOR_BLOCK_SAVED(store_index, block_index, err) if (Monitor_private.BlockSaved) {Monitor_private.BlockSaved(store_index, block_index, err);}
 
 void Longtail_SetMonitor(struct Longtail_Monitor* monitor)
 {
@@ -4446,9 +4452,9 @@ struct WriteBlockJob
     struct Longtail_StoredBlock* m_StoredBlock;
     const char* m_AssetsFolder;
     const struct Longtail_StoreIndex* m_StoreIndex;
+    const struct Longtail_VersionIndex* m_VersionIndex;
     struct AssetPartLookup* m_AssetPartLookup;
     uint32_t m_BlockIndex;
-    const char* m_PathData;
     int m_PutStoredBlockErr;
 };
 
@@ -4520,8 +4526,11 @@ static int WriteContentBlockJob(void* context, uint32_t job_id, int detected_err
     {
         // We got a notification so we are complete
         job->m_AsyncCompleteAPI.OnComplete = 0;
+        LONGTAIL_MONITOR_BLOCK_SAVED(job->m_StoreIndex, job->m_BlockIndex, job->m_PutStoredBlockErr);
         return job->m_PutStoredBlockErr;
     }
+
+    LONGTAIL_MONTITOR_BLOCK_COMPOSE(job->m_StoreIndex, job->m_BlockIndex);
 
     struct Longtail_StorageAPI* source_storage_api = job->m_SourceStorageAPI;
     struct Longtail_BlockStoreAPI* block_store_api = job->m_BlockStoreAPI;
@@ -4562,18 +4571,20 @@ static int WriteContentBlockJob(void* context, uint32_t job_id, int detected_err
     char* block_data_buffer = p;
 
     char* write_buffer = block_data_buffer;
-    char* write_ptr = write_buffer;
 
+    uint32_t last_asset_index = 0;
     uint32_t path_name_offset = 0xffffffffu;
     uint32_t tag = 0;
 
     Longtail_StorageAPI_HOpenFile file_handle = 0;
     uint64_t asset_file_size = 0;
+    uint32_t write_offset = 0;
 
     for (uint32_t chunk_index = first_chunk_index; chunk_index < first_chunk_index + chunk_count; ++chunk_index)
     {
         TLongtail_Hash chunk_hash = store_index->m_ChunkHashes[chunk_index];
         uint32_t chunk_size = store_index->m_ChunkSizes[chunk_index];
+
         uint32_t* asset_part_index = LongtailPrivate_LookupTable_Get(job->m_AssetPartLookup->m_ChunkHashToIndex, chunk_hash);
         LONGTAIL_FATAL_ASSERT(ctx, asset_part_index != 0, return EINVAL)
         uint32_t next_asset_index = *asset_part_index;
@@ -4597,10 +4608,12 @@ static int WriteContentBlockJob(void* context, uint32_t job_id, int detected_err
             {
                 source_storage_api->CloseFile(source_storage_api, file_handle);
                 file_handle = 0;
+                LONGTAIL_MONTITOR_ASSET_CLOSE(job->m_VersionIndex, last_asset_index, 0);
             }
-            const char* asset_path = &job->m_PathData[next_path_name_offset];
+            const char* asset_path = &job->m_VersionIndex->m_NameData[next_path_name_offset];
             LONGTAIL_FATAL_ASSERT(ctx, !IsDirPath(asset_path), return EINVAL)
 
+            LONGTAIL_MONTITOR_ASSET_OPEN(job->m_VersionIndex, last_asset_index);
             char* full_path = source_storage_api->ConcatPath(source_storage_api, job->m_AssetsFolder, asset_path);
             int err = source_storage_api->OpenReadFile(source_storage_api, full_path, &file_handle);
             Longtail_Free(full_path);
@@ -4611,12 +4624,15 @@ static int WriteContentBlockJob(void* context, uint32_t job_id, int detected_err
                 Longtail_Free(put_block_mem);
                 return err;
             }
+            last_asset_index = next_asset_index;
             uint64_t next_asset_file_size = 0;
             err = source_storage_api->GetSize(source_storage_api, file_handle, &next_asset_file_size);
             if (err)
             {
                 LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "source_storage_api->GetSize() failed with %d", err);
                 Longtail_Free(put_block_mem);
+                LONGTAIL_MONTITOR_ASSET_CLOSE(job->m_VersionIndex, last_asset_index, err);
+                source_storage_api->CloseFile(source_storage_api, file_handle);
                 return err;
             }
             asset_file_size = next_asset_file_size;
@@ -4630,23 +4646,27 @@ static int WriteContentBlockJob(void* context, uint32_t job_id, int detected_err
                 asset_file_size, (asset_offset + chunk_size))
             Longtail_Free(put_block_mem);
             source_storage_api->CloseFile(source_storage_api, file_handle);
+            LONGTAIL_MONTITOR_ASSET_CLOSE(job->m_VersionIndex, last_asset_index, EBADF);
             return EBADF;
         }
-        int err = source_storage_api->Read(source_storage_api, file_handle, asset_offset, chunk_size, write_ptr);
+        LONGTAIL_MONTITOR_ASSET_READ(job->m_StoreIndex, job->m_VersionIndex, next_asset_index, asset_offset, chunk_size, chunk_hash, job->m_BlockIndex, write_offset);
+        int err = source_storage_api->Read(source_storage_api, file_handle, asset_offset, chunk_size, write_buffer + write_offset);
         if (err)
         {
             LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "source_storage_api->Read() failed with %d", err);
             Longtail_Free(put_block_mem);
             source_storage_api->CloseFile(source_storage_api, file_handle);
+            LONGTAIL_MONTITOR_ASSET_CLOSE(job->m_VersionIndex, last_asset_index, err);
             return err;
         }
-        write_ptr += chunk_size;
+        write_offset += chunk_size;
     }
 
     if (file_handle)
     {
         source_storage_api->CloseFile(source_storage_api, file_handle);
         file_handle = 0;
+        LONGTAIL_MONTITOR_ASSET_CLOSE(job->m_VersionIndex, last_asset_index, 0);
     }
 
     Longtail_InitBlockIndex(block_index_ptr, chunk_count);
@@ -4665,12 +4685,14 @@ static int WriteContentBlockJob(void* context, uint32_t job_id, int detected_err
     job->m_JobID = job_id;
     job->m_AsyncCompleteAPI.OnComplete = BlockWriterJobOnComplete;
 
+    LONGTAIL_MONITOR_BLOCK_SAVE(job->m_StoreIndex, job->m_BlockIndex, put_block_mem_size);
     int err = block_store_api->PutStoredBlock(block_store_api, job->m_StoredBlock, &job->m_AsyncCompleteAPI);
     if (err)
     {
         LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "block_store_api->PutStoredBlock() failed with %d", err);
         SAFE_DISPOSE_STORED_BLOCK(job->m_StoredBlock);
         job->m_JobID = 0;
+        LONGTAIL_MONITOR_BLOCK_SAVED(job->m_StoreIndex, job->m_BlockIndex, err);
         return err;
     }
 
@@ -4789,9 +4811,9 @@ int Longtail_WriteContent(
         job->m_StoredBlock = 0;
         job->m_AssetsFolder = assets_folder;
         job->m_StoreIndex = store_index;
+        job->m_VersionIndex = version_index;
         job->m_BlockIndex = block_index;
         job->m_AssetPartLookup = asset_part_lookup;
-        job->m_PathData = version_index->m_NameData;
 
         funcs[job_count] = WriteContentBlockJob;
         ctxs[job_count] = job;

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -835,6 +835,7 @@ typedef void (*Longtail_MonitorAssetClose)(const struct Longtail_VersionIndex* v
 
 struct Longtail_Monitor
 {
+    uint64_t StructSize;
     Longtail_MonitorGetStoredBlockPrepare   BlockPrepare;
     Longtail_MonitorGetStoredBlockLoad      BlockLoad;
     Longtail_MonitorGetStoredBlockLoaded    BlockLoaded;

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -826,6 +826,13 @@ typedef void (*Longtail_MonitorAssetWrite)(const struct Longtail_StoreIndex* tar
 typedef void (*Longtail_MonitorChunkRead)(const struct Longtail_StoreIndex* store_index, const struct Longtail_VersionIndex* target_version_index, uint32_t block_index, uint32_t chunk_index, uint32_t chunk_index_in_block);
 typedef void (*Longtail_MonitorAssetComplete)(const struct Longtail_VersionIndex* target_version_index, uint32_t asset_index, int err);
 
+
+typedef void (*Longtail_MonitorBlockCompose)(const struct Longtail_StoreIndex* store_index, uint32_t block_index);
+typedef void (*Longtail_MonitorBlockSave)(const struct Longtail_StoreIndex* store_index, uint32_t block_index, uint64_t block_size);
+typedef void (*Longtail_MonitorBlockSaved)(const struct Longtail_StoreIndex* store_index, uint32_t block_index, int err);
+typedef void (*Longtail_MonitorAssetRead)(const struct Longtail_StoreIndex* store_index, const struct Longtail_VersionIndex* version_index, uint32_t asset_index, uint64_t read_offset, uint32_t size, TLongtail_Hash chunk_hash, uint32_t block_index, uint32_t block_data_offset);
+typedef void (*Longtail_MonitorAssetClose)(const struct Longtail_VersionIndex* version_index, uint32_t asset_index, int err);
+
 struct Longtail_Monitor
 {
     Longtail_MonitorGetStoredBlockPrepare   BlockPrepare;
@@ -837,6 +844,11 @@ struct Longtail_Monitor
     Longtail_MonitorAssetWrite              AssetWrite;
     Longtail_MonitorChunkRead               ChunkRead;
     Longtail_MonitorAssetComplete           AssetComplete;
+    Longtail_MonitorBlockCompose            BlockCompose;
+    Longtail_MonitorBlockSave               BlockSave;
+    Longtail_MonitorBlockSaved              BlockSaved;
+    Longtail_MonitorAssetClose              AssetClose;
+    Longtail_MonitorAssetRead               AssetRead;
 };
 
 LONGTAIL_EXPORT void Longtail_SetMonitor(struct Longtail_Monitor* monitor);

--- a/src/longtail.h
+++ b/src/longtail.h
@@ -825,8 +825,6 @@ typedef void (*Longtail_MonitorAssetOpen)(const struct Longtail_VersionIndex* ta
 typedef void (*Longtail_MonitorAssetWrite)(const struct Longtail_StoreIndex* target_store_index, const struct Longtail_VersionIndex* version_index, uint32_t asset_index, uint64_t write_offset, uint32_t size, uint32_t chunk_index, uint32_t chunk_index_in_block, uint32_t chunk_count_in_block, uint32_t block_index, uint32_t block_data_offset);
 typedef void (*Longtail_MonitorChunkRead)(const struct Longtail_StoreIndex* store_index, const struct Longtail_VersionIndex* target_version_index, uint32_t block_index, uint32_t chunk_index, uint32_t chunk_index_in_block);
 typedef void (*Longtail_MonitorAssetComplete)(const struct Longtail_VersionIndex* target_version_index, uint32_t asset_index, int err);
-
-
 typedef void (*Longtail_MonitorBlockCompose)(const struct Longtail_StoreIndex* store_index, uint32_t block_index);
 typedef void (*Longtail_MonitorBlockSave)(const struct Longtail_StoreIndex* store_index, uint32_t block_index, uint64_t block_size);
 typedef void (*Longtail_MonitorBlockSaved)(const struct Longtail_StoreIndex* store_index, uint32_t block_index, int err);


### PR DESCRIPTION
- **EXPERIMENTAL** **NEW API** `Longtail_SetMonitor` to enable more detailed feedback on `Longtail_ChangeVersion2` and `Longtail_WriteContent`. Includes simple progress UI using MiniFB and console output for upsync/downsync/pack/unpack via `--detailed-progress` option. MiniFB version only works on Windows so far, other platforms fall back to console text output.