### PR TITLE
Fix Longtail_OpenAppendFile on Linux

### DIFF
--- a/lib/longtail_platform.c
+++ b/lib/longtail_platform.c
@@ -2157,7 +2157,7 @@ int Longtail_OpenWriteFile(const char* path, uint64_t initial_size, HLongtail_Op
 
 int Longtail_OpenAppendFile(const char* path, HLongtail_OpenFile* out_write_file)
 {
-    FILE* f = fopen(path, "ab");
+    FILE* f = fopen(path, "r+");
     if (!f)
     {
         int e = errno;


### PR DESCRIPTION
While running newer versions of ```golongtail``` on Linux, I see file corruption without passing ```--use-legacy-write```. I finally found time to dig into the issue and found a problem with ```fopen``` call being made in ```Longtail_OpenAppendFile```.

According to the [pread(2)](https://man7.org/linux/man-pages/man2/pread.2.html#BUGS) man-page:

>       POSIX requires that opening a file with the O_APPEND flag should
>       have no effect on the location at which pwrite() writes data.
>       However, on Linux, if a file is opened with O_APPEND, pwrite()
>       appends data to the end of the file, regardless of the value of
>       offset.

Opening in ```O_RDWR``` mode with ```r+``` corrects the issue for me, as confirmed by a [test run](https://github.com/chris-believer/longtail/actions/runs/10985646238/job/30497831483). Since the code doesn't appear to do reads after ```OpenAppendFile``` calls I believe it matches the expected behavior, with no file creation or truncating performed. I understand if the test addition is unnecessary, it's a fairly trivial case.

Also, I just realized I left off the ```b``` in mode. I don't suspect that will be a problem, since it's unused on Linux and Mac OS systems.