### PR TITLE
Update ChangeVersion2 to handle permission changes

### DIFF
--- a/src/longtail.c
+++ b/src/longtail.c
@@ -7974,6 +7974,31 @@ static int RetainPermissions(
         }
         Longtail_Free(full_path);
     }
+
+     uint32_t version_diff_target_added_count = *version_diff->m_TargetAddedCount;
+     for (uint32_t i = 0; i < version_diff_target_added_count; ++i)
+     {
+         if ((i & 0x7f) == 0x7f) {
+             if (optional_cancel_api && optional_cancel_token && optional_cancel_api->IsCancelled(optional_cancel_api, optional_cancel_token) == ECANCELED)
+             {
+                 int err = ECANCELED;
+                 LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_DEBUG, "Operation cancelled, failed with %d", err)
+                 return err;
+             }
+         }
+         uint32_t asset_index = version_diff->m_TargetAddedAssetIndexes[i];
+         const char* asset_path = &target_version->m_NameData[target_version->m_NameOffsets[asset_index]];
+         char* full_path = version_storage_api->ConcatPath(version_storage_api, version_path, asset_path);
+         uint16_t permissions = (uint16_t)target_version->m_Permissions[asset_index];
+         int err = version_storage_api->SetPermissions(version_storage_api, full_path, permissions);
+         if (err)
+         {
+             LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "version_storage_api->SetPermissions() failed for `%s` with %d", full_path, err)
+             Longtail_Free(full_path);
+             return err;
+         }
+         Longtail_Free(full_path);
+     }
     return 0;
 }
 

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -7989,6 +7989,11 @@ static int RetainPermissions(
          uint32_t asset_index = version_diff->m_TargetAddedAssetIndexes[i];
          const char* asset_path = &target_version->m_NameData[target_version->m_NameOffsets[asset_index]];
          char* full_path = version_storage_api->ConcatPath(version_storage_api, version_path, asset_path);
+         if (full_path[strlen(full_path)-1] == '/')
+         {
+             LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_DEBUG, "Removing trailing slash from `%s`", full_path)
+             full_path[strlen(full_path) - 1] = '\0';
+         }
          uint16_t permissions = (uint16_t)target_version->m_Permissions[asset_index];
          int err = version_storage_api->SetPermissions(version_storage_api, full_path, permissions);
          if (err)

--- a/src/longtail.c
+++ b/src/longtail.c
@@ -7643,17 +7643,15 @@ int Longtail_CreateVersionDiff(
                 ++modified_content_count;
                 LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_DEBUG, "Longtail_CreateVersionDiff: Mismatching content for asset %s", source_path)
             }
-            else
+
+            uint16_t source_permissions = source_version->m_Permissions[source_asset_index];
+            uint16_t target_permissions = target_version->m_Permissions[target_asset_index];
+            if (source_permissions != target_permissions)
             {
-                uint16_t source_permissions = source_version->m_Permissions[source_asset_index];
-                uint16_t target_permissions = target_version->m_Permissions[target_asset_index];
-                if (source_permissions != target_permissions)
-                {
-                    modified_source_permissions_indexes[modified_permissions_count] = source_asset_index;
-                    modified_target_permissions_indexes[modified_permissions_count] = target_asset_index;
-                    ++modified_permissions_count;
-                    LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_DEBUG, "Longtail_CreateVersionDiff: Mismatching permissions for asset %s", source_path)
-                }
+                modified_source_permissions_indexes[modified_permissions_count] = source_asset_index;
+                modified_target_permissions_indexes[modified_permissions_count] = target_asset_index;
+                ++modified_permissions_count;
+                LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_DEBUG, "Longtail_CreateVersionDiff: Mismatching permissions for asset %s", source_path)
             }
 
             ++source_index;
@@ -8810,6 +8808,16 @@ int Longtail_ChangeVersion2(
 
     if (block_write_infos == 0)
     {
+        if (retain_permissions)
+        {
+            err = RetainPermissions(version_storage_api, optional_cancel_api, optional_cancel_token, target_version, version_diff, version_path);
+            if (err)
+            {
+                LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_ERROR, "RetainPermissions() failed with %d", err)
+                (void)concurrent_chunk_write_api->Flush(concurrent_chunk_write_api);
+                return err;
+            }
+        }
         return 0;
     }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -44,6 +44,12 @@ char* jc_test_print_value(char* buffer, size_t buffer_len, uint64_t value)
     return buffer + JC_TEST_SNPRINTF(buffer, buffer_len, "%" PRId64, value);
 }
 
+template<>
+char* jc_test_print_value(char* buffer, size_t buffer_len, uint16_t value)
+{
+    return buffer + JC_TEST_SNPRINTF(buffer, buffer_len, "%" PRId16, value);
+}
+
 static int CreateParentPath(struct Longtail_StorageAPI* storage_api, const char* path)
 {
     char* dir_path = Longtail_Strdup(path);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -8203,6 +8203,88 @@ TEST(Longtail, Longtail_CaseSensitivePaths)
     SAFE_DISPOSE_API(source_storage);
 }
 
+// Test permissions on files and folders
+TEST(Longtail, Longtail_RetainPermissions)
+{
+    static const uint32_t TARGET_CHUNK_SIZE = 16u;
+    static const uint32_t MAX_BLOCK_SIZE = 32u;
+    static const uint32_t MAX_CHUNKS_PER_BLOCK = 3u;
+
+    Longtail_StorageAPI* source_storage = Longtail_CreateInMemStorageAPI();
+    Longtail_StorageAPI* target_storage = Longtail_CreateInMemStorageAPI();
+    Longtail_CompressionRegistryAPI* compression_registry = Longtail_CreateFullCompressionRegistry();
+    Longtail_HashAPI* hash_api = Longtail_CreateBlake3HashAPI();
+    Longtail_ChunkerAPI* chunker_api = Longtail_CreateHPCDCChunkerAPI();
+    Longtail_JobAPI* job_api = Longtail_CreateBikeshedJobAPI(0, 0);
+    Longtail_BlockStoreAPI* fs_block_store_api = Longtail_CreateFSBlockStoreAPI(job_api, target_storage, "chunks", 0, 0);
+    Longtail_BlockStoreAPI* block_store_api = Longtail_CreateCompressBlockStoreAPI(fs_block_store_api, compression_registry);
+
+    const char* TEST_FILENAMES[2] = {
+        "local/file1.txt",
+        "local/file2.sh",
+    };
+
+    const uint16_t TEST_PERMISSIONS[2] = {
+        Longtail_StorageAPI_UserReadAccess | Longtail_StorageAPI_UserWriteAccess | Longtail_StorageAPI_UserExecuteAccess,
+        Longtail_StorageAPI_UserReadAccess | Longtail_StorageAPI_UserWriteAccess,
+    };
+
+    const uint16_t TEST_PERMISSIONS_MODIFIED[2] = {
+        Longtail_StorageAPI_UserReadAccess | Longtail_StorageAPI_UserWriteAccess,
+        Longtail_StorageAPI_UserReadAccess | Longtail_StorageAPI_UserWriteAccess | Longtail_StorageAPI_UserExecuteAccess,
+    };
+
+    const char* TEST_STRINGS[2] = {
+        "This is the first test string which is fairly long and should - reconstructed properly, than you very much",
+        "Short string"
+    };
+
+    for (uint32_t i = 0; i < 2; ++i)
+    {
+        ASSERT_NE(0, CreateParentPath(source_storage, TEST_FILENAMES[i]));
+        Longtail_StorageAPI_HOpenFile w;
+        ASSERT_EQ(0, source_storage->OpenWriteFile(source_storage, TEST_FILENAMES[i], 0, &w));
+        ASSERT_NE((Longtail_StorageAPI_HOpenFile)0, w);
+        ASSERT_EQ(0, source_storage->Write(source_storage, w, 0, strlen(TEST_STRINGS[i]) + 1, TEST_STRINGS[i]));
+        source_storage->CloseFile(source_storage, w);
+        source_storage->SetPermissions(source_storage, TEST_FILENAMES[i], TEST_PERMISSIONS[i]);
+        w = 0;
+    }
+
+    ASSERT_EQ(0, UploadFolder(source_storage, hash_api, chunker_api, job_api, fs_block_store_api, "local", "version.lvi", TARGET_CHUNK_SIZE, MAX_BLOCK_SIZE, MAX_CHUNKS_PER_BLOCK));
+
+    for (uint32_t i = 0; i < 2; ++i)
+    {
+        source_storage->SetPermissions(source_storage, TEST_FILENAMES[i], TEST_PERMISSIONS_MODIFIED[i]);
+    }
+
+    ASSERT_EQ(0, UploadFolder(source_storage, hash_api, chunker_api, job_api, fs_block_store_api, "local", "version_modified.lvi", TARGET_CHUNK_SIZE, MAX_BLOCK_SIZE, MAX_CHUNKS_PER_BLOCK));
+
+    ASSERT_EQ(0, DownloadFolder(source_storage, hash_api, chunker_api, job_api, fs_block_store_api, "version.lvi", "target", TARGET_CHUNK_SIZE, MAX_BLOCK_SIZE, MAX_CHUNKS_PER_BLOCK));
+
+    uint16_t permissions;
+    ASSERT_EQ(0, source_storage->GetPermissions(source_storage, "target/file1.txt", &permissions));
+    ASSERT_EQ((permissions & (Longtail_StorageAPI_UserReadAccess | Longtail_StorageAPI_UserWriteAccess | Longtail_StorageAPI_UserExecuteAccess)), TEST_PERMISSIONS[0]);
+    ASSERT_EQ(0, source_storage->GetPermissions(source_storage, "target/file2.sh", &permissions));
+    ASSERT_EQ((permissions & (Longtail_StorageAPI_UserReadAccess | Longtail_StorageAPI_UserWriteAccess)), TEST_PERMISSIONS[1]);
+
+    ASSERT_EQ(0, DownloadFolder(source_storage, hash_api, chunker_api, job_api, fs_block_store_api, "version_modified.lvi", "target", TARGET_CHUNK_SIZE, MAX_BLOCK_SIZE, MAX_CHUNKS_PER_BLOCK));
+
+    ASSERT_EQ(0, source_storage->GetPermissions(source_storage, "target/file1.txt", &permissions));
+    ASSERT_EQ((permissions & (Longtail_StorageAPI_UserReadAccess | Longtail_StorageAPI_UserWriteAccess)), TEST_PERMISSIONS_MODIFIED[0]);
+    ASSERT_EQ(0, source_storage->GetPermissions(source_storage, "target/file2.sh", &permissions));
+    ASSERT_EQ((permissions & (Longtail_StorageAPI_UserReadAccess | Longtail_StorageAPI_UserWriteAccess | Longtail_StorageAPI_UserExecuteAccess)), TEST_PERMISSIONS_MODIFIED[1]);
+
+    SAFE_DISPOSE_API(block_store_api);
+    SAFE_DISPOSE_API(fs_block_store_api);
+    SAFE_DISPOSE_API(job_api);
+    SAFE_DISPOSE_API(chunker_api);
+    SAFE_DISPOSE_API(hash_api);
+    SAFE_DISPOSE_API(compression_registry);
+    SAFE_DISPOSE_API(target_storage);
+    SAFE_DISPOSE_API(source_storage);
+}
+
 // Test writing blocks within a file in reverse order
 TEST(Longtail, Longtail_OutOfOrderWrites)
 {


### PR DESCRIPTION
Fixes #248

My initial attempt at adding a `SetPermissions` call in `RetainPermissions` caused the `VersionDiff` test to fail due to an a trailing slash on the `full_path`. Checking `version_storage_api->IsDir` did not return true, potentially due to the trailing slash as well? I added a check to strip the trailing slash in `RetainPermissions`, but if this is due to something in the test setup it may be better fixed there.

The call to `RetainPermissions` when `block_write_infos == 0` feels mostly unnecessary in practice, but seems correct if the `version_diff` could produce any diffs that do not also include block writes.