### PR TITLE
Fix potential Longtail_GetFilesRecursively2 buffer overrun.

### DIFF
--- a/src/longtail.c
+++ b/src/longtail.c
@@ -1793,7 +1793,7 @@ int Longtail_GetFilesRecursively2(
                     if (optional_cancel_api->IsCancelled(optional_cancel_api, optional_cancel_token))
                     {
                         err = ECANCELED;
-                        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_DEBUG, "Operation cancelled, failed with %d", err)
+                        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_DEBUG, "Longtail_RunJobsBatched() failed with %d", err)
                         break;
                     }
                 }
@@ -6262,7 +6262,7 @@ static int WriteAssets(
 
     if (optional_cancel_api && optional_cancel_token && optional_cancel_api->IsCancelled(optional_cancel_api, optional_cancel_token) == ECANCELED)
     {
-        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_DEBUG, "Operation cancelled, failed with %d", ECANCELED)
+        LONGTAIL_LOG(ctx, LONGTAIL_LOG_LEVEL_DEBUG, "Cancelled, failed with %d", ECANCELED)
         return ECANCELED;
     }
 


### PR DESCRIPTION
- Fix potential buffer overrun during `Longtail_GetFilesRecursively2` when using a Job API.
  - The working buffer length calculation filters paths using `IncludeFoundFile` where as setup of `job_contexts` does not. This can lead to length inconsistencies. I managed to expose this by excluding certain directories via Regex (through `golongtail` CLI) which meant that `LONGTAIL_FATAL_ASSERT(ctx, job_index == job_count, return ENOMEM);` is hit when running `golongtail` with a debug static library (`job_index > job_count`). If not debug, exits with code `0xc0000374`.